### PR TITLE
Add `as` option for `this.mount` from RouterDSL.

### DIFF
--- a/addon/router-dsl-ext.js
+++ b/addon/router-dsl-ext.js
@@ -4,9 +4,14 @@ const {
   RouterDSL: EmberRouterDSL
 } = Ember;
 
-EmberRouterDSL.prototype.mount = function(name, _options) {
+EmberRouterDSL.prototype.mount = function(_name, _options) {
   let options = _options || {};
-  let engineRouteMap = this.options.resolveRouteMap(name);
+  let engineRouteMap = this.options.resolveRouteMap(_name);
+  let name = _name;
+  if (options.as) {
+    options.resetNamespace = true;
+    name = options.as;
+  }
 
   if (engineRouteMap) {
     var fullName = getFullName(this, name, options.resetNamespace);

--- a/tests/dummy/app/templates/routeable-engine-demo.hbs
+++ b/tests/dummy/app/templates/routeable-engine-demo.hbs
@@ -1,0 +1,3 @@
+<div>
+  {{link-to 'Blog New' 'blog.new'}}
+</div>


### PR DESCRIPTION
The value of `options.as` will be used primarily, and will fallback to the name of the engine itself.

Also ensures that the engine name is reset when using `as`. When using `as` inside a nested route, linking into the engine requires only the `as` value.  Without this change, the link added here would be `{{#link-to 'routeable-engine-demo.blog.new'` instead of `{{#link-to 'blog.new'`.
