### PR TITLE
Ensure engine rendered views/components have lifecycle hooks called.

### DIFF
--- a/addon/engine-ext.js
+++ b/addon/engine-ext.js
@@ -5,7 +5,6 @@ import emberRequire from './ext-require';
 const EmberView = emberRequire('ember-views/views/view');
 const RoutingService = emberRequire('ember-routing/services/routing');
 
-
 const {
   Engine,
   SelectView,

--- a/addon/keywords/outlet.js
+++ b/addon/keywords/outlet.js
@@ -68,7 +68,13 @@ outlet.render = function(renderNode, _env, scope, params, hash, template, invers
       outletState: outletState.outlets,
       owner,
       renderer: _env.renderer,
-      dom: _env.renderer._dom,
+      dom: _env.dom,
+
+      lifecycleHooks: _env.lifecycleHooks,
+      renderedViews: _env.renderedViews,
+      renderedNodes: _env.renderedNodes,
+      hasParentOutlet: _env.hasParentOutlet,
+
       meta: env.meta
     });
 

--- a/tests/acceptance/routeable-engine-demo-test.js
+++ b/tests/acceptance/routeable-engine-demo-test.js
@@ -14,11 +14,24 @@ test('can invoke components', function(assert) {
 });
 
 test('can render a link', function(assert) {
+  assert.expect(2);
+
   visit('/routeable-engine-demo/blog/post/1');
 
   andThen(() => {
     assert.equal(currentURL(), '/routeable-engine-demo/blog/post/1');
 
     assert.equal(this.application.$('a.routeable-post-comments-link').attr('href'), '/routeable-engine-demo/blog/post/1/comments');
+  });
+});
+
+test('internal links can be clicked', function(assert) {
+  assert.expect(1);
+
+  visit('/routeable-engine-demo/blog/post/1');
+  click('.routeable-post-comments-link');
+
+  andThen(() => {
+    assert.equal(currentURL(), '/routeable-engine-demo/blog/post/1/comments');
   });
 });

--- a/tests/dummy/lib/ember-blog/addon/templates/post.hbs
+++ b/tests/dummy/lib/ember-blog/addon/templates/post.hbs
@@ -1,1 +1,3 @@
 {{#link-to 'post.comments' 1 class="routeable-post-comments-link"}}Comments{{/link-to}}
+
+{{outlet}}

--- a/tests/dummy/lib/ember-blog/addon/templates/post/comments.hbs
+++ b/tests/dummy/lib/ember-blog/addon/templates/post/comments.hbs
@@ -1,0 +1,1 @@
+Comments go here!


### PR DESCRIPTION
If we do not share the parent `env`'s `lifecycleHooks` array, then we will never have `didInsertElement`, `willDestroy`, etc hooks called.  If `didInsertElement` is not called, the view is not registered with the `_viewRegistry` which means that no actions can be dispatched (since the app/global EventDispatcher will not be aware of the engines views).
