### PR TITLE
Introduce dependency sharing

### DIFF
--- a/addon/keywords/mount.js
+++ b/addon/keywords/mount.js
@@ -117,18 +117,14 @@ registerKeyword('mount', {
     );
 
     let engineName = params[0];
-    let engineKey = `engine:${engineName}`;
 
     assert(
       'You used `{{mount \'' + engineName + '\'}}`, but the engine \'' + engineName + '\' can not be found.',
-      owner.hasRegistration(engineKey)
+      owner.hasRegistration(`engine:${engineName}`)
     );
 
-    let Engine = owner.lookup(engineKey);
-
-    let engineInstance = Engine.buildInstance();
-
-    engineInstance.boot({parent: owner});
+    let engineInstance = owner.buildChildEngineInstance(engineName);
+    engineInstance.boot();
 
     let engineController = engineInstance.lookup('controller:application');
 

--- a/addon/route-ext.js
+++ b/addon/route-ext.js
@@ -1,22 +1,25 @@
 import Ember from 'ember';
 
 const {
+  assert,
   Route,
   getOwner,
   run
 } = Ember;
 
 Route.reopen({
-  mount(engine, options) {
+  mount(engineName, options) {
     console.log('mount', options);
 
     let owner = getOwner(this);
 
-    let Engine = owner.lookup(`engine:${engine}`);
+    assert(
+      'You used `Route.mount(\'' + engineName + '\')`, but the engine \'' + engineName + '\' can not be found.',
+      owner.hasRegistration(`engine:${engineName}`)
+    );
 
-    let engineInstance = Engine.buildInstance();
-
-    engineInstance.boot({parent: owner});
+    let engineInstance = owner.buildChildEngineInstance(engineName);
+    engineInstance.boot();
 
     let template = engineInstance.lookup('template:application');
     let controller = engineInstance.lookup('controller:application');

--- a/addon/router-ext.js
+++ b/addon/router-ext.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import emberRequire from './ext-require';
 
 const {
+  assert,
   Router: EmberRouter,
   RouterDSL: EmberRouterDSL,
   getOwner,
@@ -52,11 +53,13 @@ EmberRouter.reopen({
 
     if (!engineInstance) {
       let owner = getOwner(this);
-      let Engine = owner.lookup('engine:' + name);
 
-      // TODO: throw if engine can't be found (or should we make a default?)
-      engineInstance = Engine.buildInstance({
-        parent: owner,
+      assert(
+        'You attempted to mount the engine \'' + name + '\' in your router map, but the engine can not be found.',
+        owner.hasRegistration(`engine:${name}`)
+      );
+
+      engineInstance = owner.buildChildEngineInstance(name, {
         routeable: true,
         mountPoint
       });

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -10,7 +10,24 @@ Ember.MODEL_FACTORY_INJECTIONS = true;
 App = Ember.Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
-  Resolver
+  Resolver,
+
+  engines: {
+    emberBlog: {
+      dependencies: {
+        services: [
+          {'data-store': 'store'}
+        ]
+      }
+    },
+    emberChat: {
+      dependencies: {
+        services: [
+          'store'
+        ]
+      }
+    }
+  }
 });
 
 loadInitializers(App, config.modulePrefix);

--- a/tests/dummy/lib/ember-blog/addon/engine.js
+++ b/tests/dummy/lib/ember-blog/addon/engine.js
@@ -4,5 +4,11 @@ import Resolver from 'ember-resolver';
 export default Ember.Engine.extend({
   modulePrefix: 'ember-blog',
 
-  Resolver
+  Resolver,
+
+  dependencies: {
+    services: [
+      'data-store'
+    ]
+  }
 });

--- a/tests/dummy/lib/ember-chat/addon/engine.js
+++ b/tests/dummy/lib/ember-chat/addon/engine.js
@@ -4,5 +4,11 @@ import Resolver from 'ember-resolver';
 export default Ember.Engine.extend({
   modulePrefix: 'ember-chat',
 
-  Resolver
+  Resolver,
+
+  dependencies: {
+    services: [
+      'store'
+    ]
+  }
 });

--- a/tests/unit/engine-instance-test.js
+++ b/tests/unit/engine-instance-test.js
@@ -1,0 +1,153 @@
+import Ember from 'ember';
+import EnginesInitializer from '../../initializers/engines';
+import { module, test } from 'qunit';
+
+const {
+  Engine,
+  run
+} = Ember;
+
+let MainEngine, mainEngine, mainEngineInstance;
+
+module('Unit | EngineInstance', {
+  setup() {
+    EnginesInitializer.initialize();
+
+    MainEngine = Engine.extend({
+      router: null
+    });
+
+    run(function() {
+      mainEngine = MainEngine.create();
+    });
+  },
+
+  teardown() {
+    if (mainEngineInstance) {
+      run(mainEngineInstance, 'destroy');
+    }
+
+    if (mainEngine) {
+      run(mainEngine, 'destroy');
+    }
+  }
+});
+
+test('it works', function(assert) {
+  assert.ok(true);
+});
+
+test('it can build a child engine instance with no dependencies', function(assert) {
+  assert.expect(3);
+
+  let BlogEngine = Engine.extend({ router: null });
+
+  mainEngine.register('engine:blog', BlogEngine);
+
+  let mainEngineInstance = mainEngine.buildInstance();
+
+  let blogEngineInstance = mainEngineInstance.buildChildEngineInstance('blog');
+
+  assert.ok(blogEngineInstance);
+  assert.strictEqual(blogEngineInstance.parent, mainEngineInstance, 'parent is assigned');
+
+  blogEngineInstance.cloneCoreDependencies = function() {
+    assert.ok(true, 'cloneCoreDependencies called');
+  };
+
+  return blogEngineInstance.boot();
+});
+
+test('it can build a child engine instance with dependencies', function(assert) {
+  assert.expect(4);
+
+  let storeService = {};
+  mainEngine.register('service:store', storeService, { instantiate: false });
+
+  let BlogEngine = Engine.extend({
+    router: null,
+    dependencies: {
+      services: [
+        'store'
+      ]
+    }
+  });
+
+  mainEngine.engines = {
+    blog: {
+      dependencies: {
+        services: [
+          'store'
+        ]
+      }
+    }
+  };
+
+  mainEngine.register('engine:blog', BlogEngine);
+
+  let mainEngineInstance = mainEngine.buildInstance();
+
+  let blogEngineInstance = mainEngineInstance.buildChildEngineInstance('blog');
+
+  assert.ok(blogEngineInstance);
+  assert.strictEqual(blogEngineInstance.parent, mainEngineInstance, 'parent is assigned');
+
+  blogEngineInstance.cloneCoreDependencies = function() {
+    assert.ok(true, 'cloneCoreDependencies called');
+  };
+
+  return blogEngineInstance.boot().then(() => {
+    assert.strictEqual(
+      blogEngineInstance.lookup('service:store'),
+      mainEngineInstance.lookup('service:store'),
+      'services are identical'
+    );
+  });
+});
+
+test('it can build a child engine instance with dependencies that are aliased', function(assert) {
+  assert.expect(4);
+
+  let storeService = {};
+  mainEngine.register('service:store', storeService, { instantiate: false });
+
+  let BlogEngine = Engine.extend({
+    router: null,
+    dependencies: {
+      services: [
+        'data-store' // NOTE: Blog engine uses alias to 'store'
+      ]
+    }
+  });
+
+  mainEngine.engines = {
+    blog: {
+      dependencies: {
+        services: [
+          {'data-store': 'store'} // NOTE: Main engine provides alias
+        ]
+      }
+    }
+  };
+
+  mainEngine.register('engine:blog', BlogEngine);
+
+  let mainEngineInstance = mainEngine.buildInstance();
+
+  let blogEngineInstance = mainEngineInstance.buildChildEngineInstance('blog');
+
+  assert.ok(blogEngineInstance);
+  assert.strictEqual(blogEngineInstance.parent, mainEngineInstance, 'parent is assigned');
+
+  blogEngineInstance.cloneCoreDependencies = function() {
+    assert.ok(true, 'cloneCoreDependencies called');
+  };
+
+  return blogEngineInstance.boot().then(() => {
+    assert.strictEqual(
+      blogEngineInstance.lookup('service:data-store'),
+      mainEngineInstance.lookup('service:store'),
+      'aliased services are identical'
+    );
+  });
+});


### PR DESCRIPTION
New method `EngineInstance#buildChildEngineInstance` fully handles child engine instance creation:
- It looks up an Engine and instantiates its corresponding EngineInstance.
- Dependencies are mapped from the parent to the instance.
- Dependency mappings are cached for faster subsequent instantiations.
