### PR TITLE
Track parents of engine instances using symbol.

### DIFF
--- a/addon/engine-instance-ext.js
+++ b/addon/engine-instance-ext.js
@@ -1,4 +1,8 @@
 import Ember from 'ember';
+import {
+  getEngineParent,
+  setEngineParent
+} from './engine-parent';
 
 const {
   Error: EmberError,
@@ -8,8 +12,6 @@ const {
 } = Ember;
 
 EngineInstance.reopen({
-  parent: null,
-
   /**
     The root DOM element of the `EngineInstance` as an element or a
     [jQuery-compatible selector
@@ -104,11 +106,11 @@ EngineInstance.reopen({
       throw new EmberError(`You attempted to mount the engine '${name}', but it can not be found.`);
     }
 
-    options.parent = this;
-
     options.dependencies = dependencies;
 
     let engineInstance = Engine.buildInstance(options);
+
+    setEngineParent(engineInstance, this);
 
     return engineInstance;
   },
@@ -131,7 +133,7 @@ EngineInstance.reopen({
 
     if (this._bootPromise) { return this._bootPromise; }
 
-    assert('`parent` is a required to be set prior to calling `EngineInstance#boot` ', this.parent);
+    assert('An engine instance\'s parent must be set via `setEngineParent(engine, parent)` prior to calling `engine.boot()` ', getEngineParent(this));
 
     this._bootPromise = new RSVP.Promise(resolve => resolve(this._bootSync(options)));
 
@@ -207,7 +209,7 @@ EngineInstance.reopen({
   },
 
   cloneCoreDependencies() {
-    let parent = this.parent;
+    let parent = getEngineParent(this);
 
     [
       'view:toplevel',

--- a/addon/engine-parent.js
+++ b/addon/engine-parent.js
@@ -1,0 +1,13 @@
+import emberRequire from './ext-require';
+
+const symbol = emberRequire('ember-metal/symbol');
+
+export const ENGINE_PARENT = symbol('ENGINE_PARENT');
+
+export function getEngineParent(engine) {
+  return engine[ENGINE_PARENT];
+}
+
+export function setEngineParent(engine, parent) {
+  engine[ENGINE_PARENT] = parent;
+}

--- a/tests/unit/engine-instance-test.js
+++ b/tests/unit/engine-instance-test.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import EnginesInitializer from '../../initializers/engines';
+import { getEngineParent } from 'ember-engines/engine-parent';
 import { module, test } from 'qunit';
 
 const {
@@ -49,7 +50,7 @@ test('it can build a child engine instance with no dependencies', function(asser
   let blogEngineInstance = mainEngineInstance.buildChildEngineInstance('blog');
 
   assert.ok(blogEngineInstance);
-  assert.strictEqual(blogEngineInstance.parent, mainEngineInstance, 'parent is assigned');
+  assert.strictEqual(getEngineParent(blogEngineInstance), mainEngineInstance, 'parent is assigned');
 
   blogEngineInstance.cloneCoreDependencies = function() {
     assert.ok(true, 'cloneCoreDependencies called');
@@ -90,7 +91,7 @@ test('it can build a child engine instance with dependencies', function(assert) 
   let blogEngineInstance = mainEngineInstance.buildChildEngineInstance('blog');
 
   assert.ok(blogEngineInstance);
-  assert.strictEqual(blogEngineInstance.parent, mainEngineInstance, 'parent is assigned');
+  assert.strictEqual(getEngineParent(blogEngineInstance), mainEngineInstance, 'parent is assigned');
 
   blogEngineInstance.cloneCoreDependencies = function() {
     assert.ok(true, 'cloneCoreDependencies called');
@@ -137,7 +138,7 @@ test('it can build a child engine instance with dependencies that are aliased', 
   let blogEngineInstance = mainEngineInstance.buildChildEngineInstance('blog');
 
   assert.ok(blogEngineInstance);
-  assert.strictEqual(blogEngineInstance.parent, mainEngineInstance, 'parent is assigned');
+  assert.strictEqual(getEngineParent(blogEngineInstance), mainEngineInstance, 'parent is assigned');
 
   blogEngineInstance.cloneCoreDependencies = function() {
     assert.ok(true, 'cloneCoreDependencies called');


### PR DESCRIPTION
Introduces the `ENGINE_PARENT` symbol, as well as the `getEngineParent`
and `setEngineParent` helper methods.

[Closes #2]
