### PR TITLE
Export engine and engine-instance modules.

### DIFF
--- a/addon/-private/engine-ext.js
+++ b/addon/-private/engine-ext.js
@@ -3,9 +3,9 @@ import emberRequire from './ext-require';
 
 const EmberView = emberRequire('ember-views/views/view');
 const RoutingService = emberRequire('ember-routing/services/routing');
+const Engine = emberRequire('ember-application/system/engine');
 
 const {
-  Engine,
   SelectView,
   OutletView,
   TextField,

--- a/addon/-private/engine-instance-ext.js
+++ b/addon/-private/engine-instance-ext.js
@@ -3,10 +3,12 @@ import {
   getEngineParent,
   setEngineParent
 } from './engine-parent';
+import emberRequire from './ext-require';
+
+const EngineInstance = emberRequire('ember-application/system/engine-instance');
 
 const {
   Error: EmberError,
-  EngineInstance,
   assert,
   RSVP
 } = Ember;

--- a/addon/engine-instance.js
+++ b/addon/engine-instance.js
@@ -1,0 +1,7 @@
+import emberRequire from './-private/ext-require';
+
+// Because feature flags are only valid for Ember canary builds,
+// `Ember.EngineInstance` won't be exposed publicly for beta builds. This export
+// provides a means to use this module with any ember build which privately
+// includes the `engine-instance` module.
+export default emberRequire('ember-application/system/engine-instance');

--- a/addon/engine.js
+++ b/addon/engine.js
@@ -1,0 +1,7 @@
+import emberRequire from './-private/ext-require';
+
+// Because feature flags are only valid for Ember canary builds,
+// `Ember.Engine` won't be exposed publicly for beta builds. This export
+// provides a means to use this module with any ember build which privately
+// includes the `engine` module.
+export default emberRequire('ember-application/system/engine');

--- a/addon/initializers/engines.js
+++ b/addon/initializers/engines.js
@@ -8,7 +8,6 @@ import '../-private/keywords/outlet';
 import '../-private/router-dsl-ext';
 import '../-private/link-to-component-ext';
 
-
 // TODO: Move to ensure they are ran prior to instantiating Ember.Application
 export function initialize() {
 }

--- a/tests/dummy/lib/ember-blog/addon/engine.js
+++ b/tests/dummy/lib/ember-blog/addon/engine.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
-import Resolver from 'ember-resolver';
+import Engine from 'ember-engines/engine';
+import Resolver from 'ember-engines/resolver';
 
-export default Ember.Engine.extend({
+export default Engine.extend({
   modulePrefix: 'ember-blog',
 
   Resolver,

--- a/tests/dummy/lib/ember-chat/addon/engine.js
+++ b/tests/dummy/lib/ember-chat/addon/engine.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
-import Resolver from 'ember-resolver';
+import Engine from 'ember-engines/engine';
+import Resolver from 'ember-engines/resolver';
 
-export default Ember.Engine.extend({
+export default Engine.extend({
   modulePrefix: 'ember-chat',
 
   Resolver,

--- a/tests/unit/engine-instance-test.js
+++ b/tests/unit/engine-instance-test.js
@@ -1,10 +1,10 @@
 import Ember from 'ember';
 import EnginesInitializer from '../../initializers/engines';
 import { getEngineParent } from 'ember-engines/-private/engine-parent';
+import Engine from 'ember-engines/engine';
 import { module, test } from 'qunit';
 
 const {
-  Engine,
   run
 } = Ember;
 


### PR DESCRIPTION
Because feature flags are only valid for Ember canary builds,
`Ember.Engine` and `Ember.EngineInstance` won't be exposed publicly
for beta builds. To work around this, export these private modules
from this addon.
