### PR TITLE
[WIP] Keep everything in the styles tree originally present.

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -435,13 +435,19 @@ module.exports = {
         // `**/*.css` all gets merged.
         // The addon.css file has already been renamed to match `this.name`.
         // All we need to do is concatenate it down.
-        var primaryStyleTree;
+        var remergedStylesTree;
         if (engineStylesTree) {
-          primaryStyleTree = concat(engineStylesTree, {
+          var primaryStyleTree = concat(engineStylesTree, {
             allowNone: true,
             inputFiles: ['**/*.css'],
             outputFile: 'engines-dist/' + this.name + '/assets/engine.css'
           });
+
+          var styleTreeSansCSS = new Funnel(engineStylesTree, {
+            exclude: ['**/*.css']
+          });
+
+          remergedStylesTree = mergeTrees([primaryStyleTree, styleTreeSansCSS]);
         }
 
         var otherAssets;
@@ -456,7 +462,7 @@ module.exports = {
             addonsEnginesPublicTreesMerged,
             otherAssets,
             vendorCSSImportTree,
-            primaryStyleTree,
+            remergedStylesTree,
             vendorJSImportTree,
             concatTranspiledEngineTree
           ].filter(Boolean),


### PR DESCRIPTION
I'm not sure that this is correct. I need to research where these assets get moved to within the tree in [`EmberApp`](https://github.com/ember-cli/ember-cli/blob/master/lib/broccoli/ember-app.js)
