### PR TITLE
Update so that addons can accept asset objects w/ environment properties

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -299,6 +299,7 @@ module.exports = {
         var host = originalFindHost.call(this);
         var target = this._findHost();
 
+        target.env = host.env;
         target._import = host._import;
         target._getAssetPath = host._getAssetPath;
         target.otherAssets = host.otherAssets;

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -294,6 +294,7 @@ module.exports = {
         return buildExternalTree.call(this);
       };
 
+
       this.import = function(asset, options) {
         var host = originalFindHost.call(this);
         var target = this._findHost();
@@ -305,6 +306,9 @@ module.exports = {
 
         // We're delegating to the upstream EmberApp behavior for eager engines.
         if (this.lazyLoading !== true) {
+          // Asset can be an object with environment properties.
+          asset = target._getAssetPath(asset);
+
           // This is hard-coded in Ember CLI, not tied to treePaths.
           asset.replace(/^vendor/, '');
         }


### PR DESCRIPTION
Context:
We have an addon importing a vendor file and specifying both a development and production version of the file. I received an error when trying to use the environment object version of the asset argument, which I traced down to the `asset.replace` (which assumes a string being passed in).

In our case, we were able to work around this simply by using a string asset path -- but thought this might be a valid use case to roll up to ember-engines.

Note:
Haven't tested this, yet. Opening mainly for comments in case there's another recommended approach or reason for sticking with string paths.