### PR TITLE
Add overwrite to mergeTrees

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -329,7 +329,7 @@ module.exports = {
             destDir: 'modules'
           });
 
-          engineBigHappyFamily = mergeTrees([engineJSTreeBackAgain, engineOtherTree])
+          engineBigHappyFamily = mergeTrees([engineJSTreeBackAgain, engineOtherTree], { overwrite: true });
         } else {
           engineBigHappyFamily = engineTree;
         }


### PR DESCRIPTION
Getting errors on Ember-CLI master from this merge. It seems to have to do with the change in how the addon tree gets processed, as both trees now have our `.eslintrc.yml` file in it.