### PR TITLE
Let ember-cli compile addon js

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -5,7 +5,7 @@ var existsSync = require('exists-sync');
 var fs = require('fs');
 var path = require('path');
 var writeFile = require('broccoli-file-creator');
-var babelTranspiler = require('broccoli-babel-transpiler');
+var Babel = require('broccoli-babel-transpiler');
 var concat = require('broccoli-concat');
 var DependencyFunnel = require('broccoli-dependency-funnel');
 var amdNameResolver = require('amd-name-resolver').moduleResolve;
@@ -21,6 +21,16 @@ var DEFAULT_CONFIG = {
   }
 };
 
+var DEFAULT_BABEL_CONFIG = {
+  modules: 'amdStrict',
+  moduleIds: true,
+  resolveModuleSource: require('amd-name-resolver').moduleResolve
+};
+
+function processBabel(tree) {
+  var options = defaultsDeep({}, DEFAULT_BABEL_CONFIG);
+  return new Babel(tree, options);
+}
 
 function findRoot() {
   var current = this;
@@ -62,11 +72,11 @@ function buildChildAppTree() {
   The config tree is a new concept for an engine.
   We need to build a separate config file for it.
  */
-function buildConfigTree(prefix) {
+function buildConfigTree() {
   // Include a module that reads the engine's configuration from its
   // meta tag and exports its contents.
   var configContents = this.getEngineConfigContents();
-  var configTree = writeFile(prefix + '/config/environment.js', configContents);
+  var configTree = writeFile('config/environment.js', configContents);
 
   return configTree;
 }
@@ -121,20 +131,18 @@ function buildEngineAppTree(engineSourceTree) {
   }
 
   var childAppTree = buildChildAppTree.call(this);
-  var childAppTreeRelocated = new Funnel(childAppTree, {
-    destDir: this.name
-  });
 
-  var engineTree = this.compileAddon(engineSourceTree);
+  // We want the config to be compiled with the engine source
+  var configTree = buildConfigTree.call(this);
+  var augmentedEngineTree = mergeTrees([configTree, childAppTree, engineSourceTree], { overwrite: true });
+  var engineTree = this.compileAddon(augmentedEngineTree);
   var engineTreeRelocated = new Funnel(engineTree, {
     srcDir: 'modules',
     destDir: '/',
     allowEmpty: true
   });
 
-  var configTree = buildConfigTree.call(this, this.name)
-
-  return mergeTrees([childAppTreeRelocated, engineTreeRelocated, configTree], { overwrite: true })
+  return engineTreeRelocated;
 }
 
 function buildVendorJSWithImports(concatTranspiledVendorJSTree) {
@@ -300,9 +308,10 @@ module.exports = {
 
         // NOT LAZY LOADING!
         // This is the scenario where we want to act like an addon.
-        var engineTree = originalTreeForAddon.apply(this, arguments);
         var childAppTree = buildChildAppTree.call(this);
-        var configTree = buildConfigTree.call(this, '/modules/' + this.name);
+        var configTree = buildConfigTree.call(this);
+        var augmentedAddonTree = mergeTrees([engineSourceTree, childAppTree, configTree], { overwrite: true });
+        var engineTree = originalTreeForAddon.call(this, augmentedAddonTree);
 
         // If this engine is lazy or any of its parents are lazy we need to remove its routes.
         var needsRouteRemoval = (findHost.call(this) !== findRoot.call(this));
@@ -334,10 +343,6 @@ module.exports = {
           engineBigHappyFamily = engineTree;
         }
 
-        var childAppTreeRelocated = new Funnel(childAppTree, {
-          destDir: 'modules/' + this.name
-        });
-
         // We only calculate our external tree for eager engines
         // if they're going to be consumed by a lazy engine.
         var externalTree;
@@ -345,7 +350,7 @@ module.exports = {
           externalTree = buildExternalTree.call(this);
         }
 
-        return mergeTrees([externalTree, childAppTreeRelocated, engineBigHappyFamily, configTree].filter(Boolean), { overwrite: true });
+        return mergeTrees([externalTree, engineBigHappyFamily].filter(Boolean), { overwrite: true });
       };
 
       // We want to do the default `treeForPublic` behavior if we're not a lazy loading engine.
@@ -403,33 +408,27 @@ module.exports = {
           external: ['ember-engines/routes']
         });
 
-        // Babelify, but only to the extent of converting modules.
-        var babelOptions = {
-          modules: 'amdStrict',
-          moduleIds: true,
-          resolveModuleSource: amdNameResolver
-        };
-
-        var transpiledEngineTree = babelTranspiler(engineAppTreeWithoutRoutes, babelOptions);
+        // If babel options aren't defined, we need to transpile the modules.
+        if (!this.options || !this.options.babel) {
+          engineAppTreeWithoutRoutes = processBabel(engineAppTreeWithoutRoutes);
+          vendorJSTree = processBabel(vendorJSTree);
+        }
 
         // Concatenate all of the engine's JavaScript into a single file.
-        var concatTranspiledEngineTree = concat(transpiledEngineTree, {
+        var concatEngineTree = concat(engineAppTreeWithoutRoutes, {
           allowNone: true,
           inputFiles: ['**/*.js'],
           outputFile: 'engines-dist/' + this.name + '/assets/engine.js'
         });
 
-        // Combine all of the "vendor" trees which have JavaScript.
-        var transpiledVendorJSTree = babelTranspiler(vendorJSTree, babelOptions);
-
-        // And concatenate them.
-        var concatTranspiledVendorJSTree = concat(transpiledVendorJSTree, {
+        // Concatenate all of the engine's "vendor" trees
+        var concatVendorJSTree = concat(vendorJSTree, {
           allowNone: true,
           inputFiles: ['**/*.js'],
           outputFile: 'engines-dist/' + this.name + '/assets/engine-vendor.js'
         });
 
-        var concatMergedVendorJSTree = mergeTrees([concatTranspiledVendorJSTree, externalTree]);
+        var concatMergedVendorJSTree = mergeTrees([concatVendorJSTree, externalTree]);
 
         // So, this is weird, but imports are processed in order.
         // This gives the chance for somebody to prepend onto the vendor files.
@@ -477,7 +476,7 @@ module.exports = {
             vendorCSSImportTree,
             primaryStyleTree,
             vendorJSImportTree,
-            concatTranspiledEngineTree
+            concatEngineTree
           ].filter(Boolean),
           { overwrite: true }
         );

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   ],
   "dependencies": {
     "amd-name-resolver": "0.0.5",
-    "broccoli-babel-transpiler": "^5.5.0",
+    "broccoli-babel-transpiler": "^5.6.1",
     "broccoli-concat": "^3.0.1",
     "broccoli-dependency-funnel": "^1.0.0",
     "broccoli-file-creator": "^1.1.0",

--- a/tests/dummy/lib/common-components/package.json
+++ b/tests/dummy/lib/common-components/package.json
@@ -5,6 +5,7 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-htmlbars": "*"
+    "ember-cli-htmlbars": "*",
+    "ember-cli-babel": "*"
   }
 }

--- a/tests/dummy/lib/ember-blog/package.json
+++ b/tests/dummy/lib/ember-blog/package.json
@@ -9,6 +9,8 @@
     "engineConfigPath": "ember-config"
   },
   "dependencies": {
-    "ember-cli-htmlbars": "*"
+    "ember-cli-htmlbars": "*",
+    "ember-cli-babel": "*",
+    "common-components": "file:../common-components"
   }
 }


### PR DESCRIPTION
Instead of manually invoking `broccoli-babel-transpiler` we will allow either `compileAddon` or `originalTreeForAddon` (both provided by Ember-CLI) to do transpiling for us. This should work on existing versions of Ember-CLI and prevents us from breaking in upcoming versions.