### PR TITLE
Build styles tree before building public tree.

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -386,16 +386,31 @@ module.exports = {
       this.treeForPublic = function() {
         // NOT LAZY LOADING!
         // In this scenario we just want to do the default behavior and bail.
-        var publicResult = originalTreeForPublic.apply(this, arguments);
-
         if (this.lazyLoading !== true) {
-          return publicResult;
+          return originalTreeForPublic.apply(this, arguments);
         }
 
         // LAZY LOADING!
         // But we have to implement everything manually for the lazy loading scenario.
 
+        // Get base styles tree.
+        var engineStylesTree = this.compileStyles(this._treeFor('addon-styles'));
+
+        // Move styles tree into the correct place.
+        // `**/*.css` all gets merged.
+        // The addon.css file has already been renamed to match `this.name`.
+        // All we need to do is concatenate it down.
+        var primaryStyleTree;
+        if (engineStylesTree) {
+          primaryStyleTree = concat(engineStylesTree, {
+            allowNone: true,
+            inputFiles: ['**/*.css'],
+            outputFile: 'engines-dist/' + this.name + '/assets/engine.css'
+          });
+        }
+
         // Move the public tree. It is already all in a folder named `this.name`
+        var publicResult = originalTreeForPublic.apply(this, arguments);
         var publicRelocated;
         if (publicResult) {
           publicRelocated = new Funnel(publicResult, {
@@ -470,22 +485,6 @@ module.exports = {
         // So, this is weird, but imports are processed in order.
         // This gives the chance for somebody to prepend onto the vendor files.
         var vendorCSSImportTree = buildVendorCSSWithImports.call(this, concatMergedVendorCSSTree);
-
-        // Get base styles tree.
-        var engineStylesTree = this.compileStyles(this._treeFor('addon-styles'));
-
-        // Move styles tree into the correct place.
-        // `**/*.css` all gets merged.
-        // The addon.css file has already been renamed to match `this.name`.
-        // All we need to do is concatenate it down.
-        var primaryStyleTree;
-        if (engineStylesTree) {
-          primaryStyleTree = concat(engineStylesTree, {
-            allowNone: true,
-            inputFiles: ['**/*.css'],
-            outputFile: 'engines-dist/' + this.name + '/assets/engine.css'
-          });
-        }
 
         var otherAssets;
         if (this.otherAssets) {
@@ -697,4 +696,4 @@ module.exports = {
     };
     return options;
   }
-}
+};


### PR DESCRIPTION
This change allows non-CSS assets to be gathered during the building of the styles tree and then later added to the public tree. For example, [ember-cli-eyeglass](https://github.com/sass-eyeglass/ember-cli-eyeglass) needs this so it can add any non-CSS assets returned from Eyeglass to the public tree.

This also makes the process for building a lazy engine consistent with how Ember CLI builds regular addons, in that it builds the styles tree before the public tree.