### PR TITLE
Align lazy and eager builds

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -156,6 +156,15 @@ function buildEngineJSTree() {
   return engineTreeRelocated;
 }
 
+function buildEngineJSTreeWithoutRoutes() {
+  var engineJSTree = buildEngineJSTree.call(this);
+  return new DependencyFunnel(engineJSTree, {
+    exclude: true,
+    entry: this.name + '/routes.js',
+    external: ['ember-engines/routes']
+  });
+}
+
 function buildEngineCSSTree() {
   return this.compileStyles(this._treeFor('addon-styles'));
 }
@@ -259,6 +268,9 @@ module.exports = {
       this._scriptOutputFiles = {};
       this._styleOutputFiles = {};
 
+      // Determines if this Engine or any of its parents are lazy
+      this._hasLazyAncestor = (findHost.call(this) !== findRoot.call(this));
+
       this._processedExternalTree = function() {
         return buildExternalTree.call(this);
       };
@@ -304,25 +316,23 @@ module.exports = {
 
       this.treeForEngine = function() {
         // If this engine is lazy or any of its parents are lazy we need to promote its routes.
-        var needsRoutePromotion = (findHost.call(this) !== findRoot.call(this));
-        if (!needsRoutePromotion) { return; }
+        if (!this._hasLazyAncestor) { return; }
 
-        // The only thing that we want to promote from a lazy engine is the routes.js file.
-        // ... and all of its dependencies.
-
+        // The only thing that we want to promote from a lazy engine is the
+        // routes.js file and all of its dependencies, which is why we build the
+        // complete JS tree.
         var completeJSTree = buildCompleteJSTree.call(this);
 
         // Splice out the routes.js file and its dependencies.
         // We will push these into the host application.
         var engineRoutesTree = new DependencyFunnel(completeJSTree, {
           include: true,
-          entry: this.name+'/routes.js',
+          entry: this.name + '/routes.js',
           external: ['ember-engines/routes']
         });
 
-        // But they need to be in the modules directory for later processing.
+        // They need to be in the modules directory for later processing.
         return new Funnel(engineRoutesTree, {
-          srcDir: '/',
           destDir: 'modules',
           allowEmpty: true
         });
@@ -335,21 +345,14 @@ module.exports = {
 
         // NOT LAZY LOADING!
         // This is the scenario where we want to act like an addon.
-        var engineJSTree = buildEngineJSTree.call(this);
         var engineCSSTree = buildEngineCSSTree.call(this);
 
-        // If this engine is lazy or any of its parents are lazy we need to remove its routes.
-        var needsRouteRemoval = (findHost.call(this) !== findRoot.call(this));
-        if (needsRouteRemoval) {
-          // But we've already accounted for our routes with the `treeForEngine` hook.
-          var engineJSTreeWithoutRoutes = new DependencyFunnel(engineJSTree, {
-            exclude: true,
-            entry: this.name+'/routes.js',
-            external: ['ember-engines/routes']
-          });
-
-          engineJSTree = engineJSTreeWithoutRoutes;
-        }
+        // If this engine is lazy or any of its parents are lazy we need to
+        // remove its routes, because we've already accounted for our routes
+        // with the `treeForEngine` hook.
+        var engineJSTree = this._hasLazyAncestor ?
+          buildEngineJSTreeWithoutRoutes.call(this) :
+          buildEngineJSTree.call(this);
 
         // Move the Engine tree to `modules`
         engineJSTree = new Funnel(engineJSTree, {
@@ -429,25 +432,20 @@ module.exports = {
         var vendorJSTree = buildVendorJSTree.call(this, vendorTree);
         var vendorCSSTree = buildVendorCSSTree.call(this, vendorTree);
         var externalTree = new Funnel(vendorTree, {
-          include: ['vendor/**/*.*']
+          srcDir: 'vendor',
+          allowEmpty: true
         });
-        var engineAppTree = buildEngineJSTree.call(this);
 
-        // Splice out the routes.js file which we pushed into the host application.
-        var engineAppTreeWithoutRoutes = new DependencyFunnel(engineAppTree, {
-          exclude: true,
-          entry: this.name+'/routes.js',
-          external: ['ember-engines/routes']
-        });
+        var engineJSTree = buildEngineJSTreeWithoutRoutes.call(this);
 
         // If babel options aren't defined, we need to transpile the modules.
         if (!this.options || !this.options.babel) {
-          engineAppTreeWithoutRoutes = processBabel(engineAppTreeWithoutRoutes);
+          engineJSTree = processBabel(engineJSTree);
           vendorJSTree = processBabel(vendorJSTree);
         }
 
         // Concatenate all of the engine's JavaScript into a single file.
-        var concatEngineTree = concat(engineAppTreeWithoutRoutes, {
+        var concatEngineTree = concat(engineJSTree, {
           allowNone: true,
           inputFiles: ['**/*.js'],
           outputFile: 'engines-dist/' + this.name + '/assets/engine.js'

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -135,17 +135,16 @@ function buildVendorCSSTree(vendorTree) {
   });
 }
 
-function buildEngineAppTree() {
+function buildEngineJSTree() {
   var engineSourceTree;
   var treePath = path.resolve(this.root, this.treePaths['addon']);
   if (existsSync(treePath)) {
     engineSourceTree = this.treeGenerator(treePath);
   }
 
-  var childAppTree = buildChildAppTree.call(this);
-
-  // We want the config to be compiled with the engine source
+  // We want the config and child app trees to be compiled with the engine source
   var configTree = buildConfigTree.call(this);
+  var childAppTree = buildChildAppTree.call(this);
   var augmentedEngineTree = mergeTrees([configTree, childAppTree, engineSourceTree].filter(Boolean), { overwrite: true });
   var engineTree = this.compileAddon(augmentedEngineTree);
   var engineTreeRelocated = new Funnel(engineTree, {
@@ -155,6 +154,10 @@ function buildEngineAppTree() {
   });
 
   return engineTreeRelocated;
+}
+
+function buildEngineCSSTree() {
+  return this.compileStyles(this._treeFor('addon-styles'));
 }
 
 function buildVendorJSWithImports(concatTranspiledVendorJSTree) {
@@ -203,7 +206,7 @@ function buildVendorCSSWithImports(concatVendorCSSTree) {
 function buildCompleteJSTree() {
   var vendorTree = buildVendorTree.call(this);
   var vendorJSTree = buildVendorJSTree.call(this, vendorTree);
-  var engineAppTree = buildEngineAppTree.call(this);
+  var engineAppTree = buildEngineJSTree.call(this);
 
   return mergeTrees(
     [
@@ -327,46 +330,31 @@ module.exports = {
 
       // Replace `treeForAddon` so that we control how this engine gets built.
       // We may or may not want it to be combined like a default addon.
-      var originalTreeForAddon = this.treeForAddon;
       this.treeForAddon = function(engineSourceTree) {
         if (this.lazyLoading === true) { return; }
 
         // NOT LAZY LOADING!
         // This is the scenario where we want to act like an addon.
-        var childAppTree = buildChildAppTree.call(this);
-        var configTree = buildConfigTree.call(this);
-        var augmentedAddonTree = mergeTrees([engineSourceTree, childAppTree, configTree], { overwrite: true });
-        var engineTree = originalTreeForAddon.call(this, augmentedAddonTree);
+        var engineJSTree = buildEngineJSTree.call(this);
+        var engineCSSTree = buildEngineCSSTree.call(this);
 
         // If this engine is lazy or any of its parents are lazy we need to remove its routes.
         var needsRouteRemoval = (findHost.call(this) !== findRoot.call(this));
-
-        var engineBigHappyFamily;
         if (needsRouteRemoval) {
-          var engineOtherTree = new Funnel(engineTree, {
-            exclude: ['modules', 'modules/**/*.*']
-          });
-
-          var engineJSTreeThere = new Funnel(engineTree, {
-            srcDir: 'modules',
-            allowEmpty: true
-          });
-
           // But we've already accounted for our routes with the `treeForEngine` hook.
-          var engineJSTreeWithoutRoutes = new DependencyFunnel(engineJSTreeThere, {
+          var engineJSTreeWithoutRoutes = new DependencyFunnel(engineJSTree, {
             exclude: true,
             entry: this.name+'/routes.js',
             external: ['ember-engines/routes']
           });
 
-          var engineJSTreeBackAgain = new Funnel(engineJSTreeWithoutRoutes, {
-            destDir: 'modules'
-          });
-
-          engineBigHappyFamily = mergeTrees([engineJSTreeBackAgain, engineOtherTree], { overwrite: true });
-        } else {
-          engineBigHappyFamily = engineTree;
+          engineJSTree = engineJSTreeWithoutRoutes;
         }
+
+        // Move the Engine tree to `modules`
+        engineJSTree = new Funnel(engineJSTree, {
+          destDir: 'modules'
+        });
 
         // We only calculate our external tree for eager engines
         // if they're going to be consumed by a lazy engine.
@@ -375,7 +363,11 @@ module.exports = {
           externalTree = buildExternalTree.call(this);
         }
 
-        return mergeTrees([externalTree, engineBigHappyFamily].filter(Boolean), { overwrite: true });
+        return mergeTrees([
+          externalTree,
+          engineJSTree,
+          engineCSSTree
+        ].filter(Boolean), { overwrite: true });
       };
 
       // We want to do the default `treeForPublic` behavior if we're not a lazy loading engine.
@@ -394,7 +386,7 @@ module.exports = {
         // But we have to implement everything manually for the lazy loading scenario.
 
         // Get base styles tree.
-        var engineStylesTree = this.compileStyles(this._treeFor('addon-styles'));
+        var engineStylesTree = buildEngineCSSTree.call(this);
 
         // Move styles tree into the correct place.
         // `**/*.css` all gets merged.
@@ -439,7 +431,7 @@ module.exports = {
         var externalTree = new Funnel(vendorTree, {
           include: ['vendor/**/*.*']
         });
-        var engineAppTree = buildEngineAppTree.call(this);
+        var engineAppTree = buildEngineJSTree.call(this);
 
         // Splice out the routes.js file which we pushed into the host application.
         var engineAppTreeWithoutRoutes = new DependencyFunnel(engineAppTree, {


### PR DESCRIPTION
In order to more effectively cache builds and have an easier to understand build process, we want to align lazy and eager (non-lazy) build processes. Right now the two types of builds do a lot of similar steps, but don't share any underlying implementation, this PR will seek to share as much implementation as is reasonably possible.