### PR TITLE
Lookup asset-loader instead of injecting it

### DIFF
--- a/addon/-private/router-ext.js
+++ b/addon/-private/router-ext.js
@@ -15,11 +15,13 @@ const {
 } = Ember;
 
 Router.reopen({
-  assetLoader: Ember.inject.service(),
-
   init() {
     this._super(...arguments);
     this._enginePromises = Object.create(null);
+
+    // We lookup the asset loader service instead of injecting it so that we
+    // don't blow up unit tests for consumers
+    this._assetLoader = getOwner(this).lookup('service:asset-loader');
   },
 
   /**
@@ -205,7 +207,7 @@ Router.reopen({
       enginePromise = RSVP.resolve();
     } else {
       // The Engine is not loaded and has no Promise
-      enginePromise = this.get('assetLoader').loadBundle(name).then(() => this._registerEngine(name));
+      enginePromise = this._assetLoader.loadBundle(name).then(() => this._registerEngine(name));
     }
 
     return enginePromises[name][instanceId] = enginePromise.then(() => {

--- a/tests/unit/components/link-to-external-test.js
+++ b/tests/unit/components/link-to-external-test.js
@@ -1,0 +1,11 @@
+import { moduleForComponent, test } from 'ember-qunit';
+
+moduleForComponent('link-to-external', 'Unit | Component | link-to-external', {
+  unit: true
+});
+
+test('it renders properly', function(assert) {
+  let component = this.subject({ params: [ 'index' ] });
+  this.render();
+  assert.ok(component.element, 'render an element');
+});


### PR DESCRIPTION
Addressing https://github.com/ember-engines/ember-engines/issues/294.

I think this solution will be fine to roll with. If a unit/integration attempts to do a transition, it could still hit an issue with the asset-loader not being present, but I don't believe unit/integration tests should be hitting that code path.

Another alternative is to move the service injection into an initializer, but I am unsure if that is better than this approach. I feel like this approach is less "magical" because it does not involve an additional external file.