### PR TITLE
Run build tests only if appropriate changes were made

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ cache:
 env:
   - TEST_SCRIPT=test:ember EMBER_TRY_SCENARIO=ember-canary
   - TEST_SCRIPT=test:ember EMBER_TRY_SCENARIO=ember-beta
-  - TEST_SCRIPT=test:node
+
+  # Run the node build tests only if we've modified a build file
+  - TEST_SCRIPT=test:node:ci
 
 matrix:
   fast_finish: true

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "test:ember": "ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup",
     "test:node": "mocha node-tests/**/*-test.js --reporter tap",
     "test:windows": "ember try:one %EMBER_TRY_SCENARIO% test --skip-cleanup",
-    "test:dev:node": "BUILD_DEV=true testem -f testem-node.js",
+    "test:node:dev": "BUILD_DEV=true testem -f testem-node.js",
+    "test:node:ci": "git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qE '^(lib|index.js|node-tests|package.json)' && npm run test:node || npm run test:null",
+    "test:null": "echo 'no appropriate changes detected, not running tests'",
     "prepublish": "node ./bin/install-test-addons.js"
   },
   "repository": {


### PR DESCRIPTION
Updates Travis to only run build tests when `lib/*` or `index.js` are changed.