### PR TITLE
Properly link-to engine's application route

### DIFF
--- a/addon/-private/link-to-component.js
+++ b/addon/-private/link-to-component.js
@@ -16,15 +16,25 @@ export default LinkComponent.extend({
 
     if (owner.mountPoint) {
       // Prepend engine mount point to targetRouteName
-      let fullRouteName = owner.mountPoint + '.' + get(this, 'targetRouteName');
-      set(this, 'targetRouteName', fullRouteName);
+      this._prefixProperty(owner.mountPoint, 'targetRouteName');
 
       // Prepend engine mount point to current-when if set
-      let currentWhen = get(this, 'current-when');
-      if (currentWhen !== null) {
-        let fullCurrentWhen = owner.mountPoint + '.' + currentWhen;
-        set(this, 'current-when', fullCurrentWhen);
+      if (get(this, 'current-when') !== null) {
+        this._prefixProperty(owner.mountPoint, 'current-when');
       }
     }
+  },
+
+  _prefixProperty(prefix, prop) {
+    let propValue = get(this, prop);
+
+    let namespacedPropValue;
+    if (propValue === 'application') {
+      namespacedPropValue = prefix;
+    } else {
+      namespacedPropValue = prefix + '.' + propValue;
+    }
+
+    set(this, prop, namespacedPropValue);
   }
 });

--- a/tests/acceptance/routeable-engine-demo-test.js
+++ b/tests/acceptance/routeable-engine-demo-test.js
@@ -31,6 +31,15 @@ test('can deserialize a route\'s params', function(assert) {
   });
 });
 
+test('can link-to application route of Engine', function(assert) {
+  visit('/routable-engine-demo/blog/post/new');
+  click('.routable-post-blog-home-link-app');
+  andThen(() => {
+    assert.equal(currentURL(), '/routable-engine-demo/blog');
+    assert.equal(currentPath(), 'routable-engine-demo.blog.index');
+  });
+});
+
 test('correctly handles navigation with query param in initial url', function(assert) {
   assert.expect(9);
 

--- a/tests/dummy/lib/ember-blog/addon/templates/post.hbs
+++ b/tests/dummy/lib/ember-blog/addon/templates/post.hbs
@@ -14,6 +14,7 @@
 
 {{#link-to-external "home" class="routable-post-home-link"}}Go home{{/link-to-external}}
 {{#link-to "index" class="routable-post-blog-home-link"}}Go to blog home{{/link-to}}
+{{#link-to "application" class="routable-post-blog-home-link-app"}}Also goes to blog home{{/link-to}}
 
 {{#link-to (query-params lang="Japanese") class="routable-post-jp-link"}}Go to Japanese version{{/link-to}}
 <button {{action "goToChineseVersion"}} class="routable-post-ch-link">Go to Chinese version</button>


### PR DESCRIPTION
While addressing https://github.com/ember-engines/ember-engines.com/issues/8 I found a bug in the current implementation.