### PR TITLE
Memoize build functions

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -12,6 +12,7 @@ var amdNameResolver = require('amd-name-resolver').moduleResolve;
 var defaultsDeep = require('lodash.defaultsdeep');
 var calculateCacheKeyForTree = require('calculate-cache-key-for-tree');
 var Addon = require('ember-cli/lib/models/addon');
+var memoize = require('./utils/memoize');
 
 var ADDON_TREE_CACHING = (function() {
   try {
@@ -76,42 +77,42 @@ function findHost() {
   This is an extraction of what would normally be run by the `treeFor` hook.
   Because we call it in two different places we've moved it to a utility function.
  */
-function buildChildAppTree() {
+var buildChildAppTree = memoize(function buildChildAppTree() {
   var treesForApp = this.eachAddonInvoke('treeFor', ['app']);
   return mergeTrees(treesForApp, { overwrite: true });
-}
+});
 
 /**
   The config tree is a new concept for an engine.
   We need to build a separate config file for it.
  */
-function buildConfigTree() {
+var buildConfigTree = memoize(function buildConfigTree() {
   // Include a module that reads the engine's configuration from its
   // meta tag and exports its contents.
   var configContents = this.getEngineConfigContents();
   var configTree = writeFile('config/environment.js', configContents);
 
   return configTree;
-}
+});
 
-function buildExternalTree() {
+var buildExternalTree = memoize(function buildExternalTree() {
   var vendorPath = path.resolve(this.root, this.treePaths['vendor']);
   if (!existsSync(vendorPath)) { return; }
 
   return new Funnel(vendorPath, {
     destDir: 'vendor'
   });
-}
+});
 
-function buildVendorTree() {
+var buildVendorTree = memoize(function buildVendorTree() {
   // Manually invoke the child addons addon trees.
   var childAddonsAddonTrees = this.eachAddonInvoke('treeFor', ['addon', 'buildVendorTree']);
   var childAddonsAddonTreesMerged = mergeTrees(childAddonsAddonTrees, { overwrite: true });
 
   return childAddonsAddonTreesMerged;
-}
+});
 
-function buildVendorJSTree(vendorTree) {
+var buildVendorJSTree = memoize(function buildVendorJSTree(vendorTree) {
   // Filter out the JS so that we can process it correctly.
   var vendorJSTree = new Funnel(vendorTree, {
     include: ['**/*.js'],
@@ -125,17 +126,17 @@ function buildVendorJSTree(vendorTree) {
   });
 
   return vendorJSTreeRelocated;
-}
+});
 
-function buildVendorCSSTree(vendorTree) {
+var buildVendorCSSTree = memoize(function buildVendorCSSTree(vendorTree) {
   // Filter out the CSS so that we can process it correctly.
   return new Funnel(vendorTree, {
     include: ['**/*.css'],
     exclude: ['vendor/**/*.*']
   });
-}
+});
 
-function buildEngineJSTree() {
+var buildEngineJSTree = memoize(function buildEngineJSTree() {
   var engineSourceTree;
   var treePath = path.resolve(this.root, this.treePaths['addon']);
   if (existsSync(treePath)) {
@@ -154,22 +155,22 @@ function buildEngineJSTree() {
   });
 
   return engineTreeRelocated;
-}
+});
 
-function buildEngineJSTreeWithoutRoutes() {
+var buildEngineJSTreeWithoutRoutes = memoize(function buildEngineJSTreeWithoutRoutes() {
   var engineJSTree = buildEngineJSTree.call(this);
   return new DependencyFunnel(engineJSTree, {
     exclude: true,
     entry: this.name + '/routes.js',
     external: ['ember-engines/routes']
   });
-}
+});
 
-function buildEngineCSSTree() {
+var buildEngineCSSTree = memoize(function buildEngineCSSTree() {
   return this.compileStyles(this._treeFor('addon-styles'));
-}
+});
 
-function buildVendorJSWithImports(concatTranspiledVendorJSTree) {
+var buildVendorJSWithImports = memoize(function buildVendorJSWithImports(concatTranspiledVendorJSTree) {
   var externalTree = buildExternalTree.call(this);
   var combined = mergeTrees([externalTree, concatTranspiledVendorJSTree].filter(Boolean), { overwrite: true });
 
@@ -189,9 +190,9 @@ function buildVendorJSWithImports(concatTranspiledVendorJSTree) {
   }
 
   return mergeTrees(vendorFiles, { overwrite: true });
-}
+});
 
-function buildVendorCSSWithImports(concatVendorCSSTree) {
+var buildVendorCSSWithImports = memoize(function buildVendorCSSWithImports(concatVendorCSSTree) {
   var externalTree = buildExternalTree.call(this);
   var combined = mergeTrees([externalTree, concatVendorCSSTree].filter(Boolean), { overwrite: true });
 
@@ -210,9 +211,9 @@ function buildVendorCSSWithImports(concatVendorCSSTree) {
   }
 
   return mergeTrees(vendorFiles, { overwrite: true });
-}
+});
 
-function buildCompleteJSTree() {
+var buildCompleteJSTree = memoize(function buildCompleteJSTree() {
   var vendorTree = buildVendorTree.call(this);
   var vendorJSTree = buildVendorJSTree.call(this, vendorTree);
   var engineAppTree = buildEngineJSTree.call(this);
@@ -224,7 +225,7 @@ function buildCompleteJSTree() {
     ],
     { overwrite: true }
   );
-}
+});
 
 module.exports = {
   extend: function(options) {

--- a/lib/utils/memoize.js
+++ b/lib/utils/memoize.js
@@ -1,0 +1,13 @@
+var calculateCacheKeyForTree = require('calculate-cache-key-for-tree');
+var CACHE = Object.create(null);
+
+module.exports = function memoize(func) {
+  return function _memoize() {
+    var cacheKey = calculateCacheKeyForTree(func.name, this);
+    if (CACHE[cacheKey]) {
+      return CACHE[cacheKey];
+    } else {
+      return (CACHE[cacheKey] = func.apply(this, arguments));
+    }
+  }
+};


### PR DESCRIPTION
We have a lot of small functions that are potentially called more than once for an Engine. By caching the return values of these functions, we can improve build performance by not doing redundant work.

The memoization done here assumes that only one output value ever occurs for the function, which is an assumption currently made by the build system.