### PR TITLE
Default `ADDON_TREE_CACHING` to `cacheKeyForTree`.

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -14,9 +14,11 @@ var calculateCacheKeyForTree = require('calculate-cache-key-for-tree');
 var Addon = require('ember-cli/lib/models/addon');
 var memoize = require('./utils/memoize');
 
+// required until stable version of ember-cli includes
+// https://github.com/ember-cli/rfcs/pull/90
 var ADDON_TREE_CACHING = (function() {
   try {
-    return require('ember-cli/lib/experiments').ADDON_TREE_CACHING;
+    return require('ember-cli/lib/experiments').ADDON_TREE_CACHING || 'cacheKeyForTree';
   } catch (e) {
     if (e.code === 'MODULE_NOT_FOUND') {
       return null;


### PR DESCRIPTION
The proposed public API for this is `cacheKeyForTree`, with this  change when the symbol is removed (i.e. the feature is stable) a new version of ember-engines will not need to be released (and users will not accidentally fall back to uncached builds).

Specific scenarios:

* In older versions of ember-cli where `ember-cli/lib/experiments` is not present, we will not add the caching method at all.

* In versions of ember-cli with `ember-cli/lib/experiments` AND `ADDON_TREE_CACHING` symbol in the experiements file: that symbol will be used to name the method.

* In versions of ember-cli with a `ember-cli/lib/experiments` file that does not contain the `ADDON_TREE_CACHING` symbol in the experiments file (i.e. it has been promoted to a full public API) the method will be named  `cacheKeyForTree`.
