### PR TITLE
Revert "Simplify DependencyFunnel scenarios"

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -271,9 +271,6 @@ module.exports = {
       this._scriptOutputFiles = {};
       this._styleOutputFiles = {};
 
-      // Determines if this Engine or any of its parents are lazy
-      this._hasLazyAncestor = (findHost.call(this) !== findRoot.call(this));
-
       this._processedExternalTree = function() {
         return buildExternalTree.call(this);
       };
@@ -319,23 +316,25 @@ module.exports = {
 
       this.treeForEngine = function() {
         // If this engine is lazy or any of its parents are lazy we need to promote its routes.
-        if (!this._hasLazyAncestor) { return; }
+        var needsRoutePromotion = (findHost.call(this) !== findRoot.call(this));
+        if (!needsRoutePromotion) { return; }
 
-        // The only thing that we want to promote from a lazy engine is the
-        // routes.js file and all of its dependencies, which is why we build the
-        // complete JS tree.
+        // The only thing that we want to promote from a lazy engine is the routes.js file.
+        // ... and all of its dependencies.
+
         var completeJSTree = buildCompleteJSTree.call(this);
 
         // Splice out the routes.js file and its dependencies.
         // We will push these into the host application.
         var engineRoutesTree = new DependencyFunnel(completeJSTree, {
           include: true,
-          entry: this.name + '/routes.js',
+          entry: this.name+'/routes.js',
           external: ['ember-engines/routes']
         });
 
-        // They need to be in the modules directory for later processing.
+        // But they need to be in the modules directory for later processing.
         return new Funnel(engineRoutesTree, {
+          srcDir: '/',
           destDir: 'modules',
           allowEmpty: true
         });
@@ -348,14 +347,21 @@ module.exports = {
 
         // NOT LAZY LOADING!
         // This is the scenario where we want to act like an addon.
+        var engineJSTree = buildEngineJSTree.call(this);
         var engineCSSTree = buildEngineCSSTree.call(this);
 
-        // If this engine is lazy or any of its parents are lazy we need to
-        // remove its routes, because we've already accounted for our routes
-        // with the `treeForEngine` hook.
-        var engineJSTree = this._hasLazyAncestor ?
-          buildEngineJSTreeWithoutRoutes.call(this) :
-          buildEngineJSTree.call(this);
+        // If this engine is lazy or any of its parents are lazy we need to remove its routes.
+        var needsRouteRemoval = (findHost.call(this) !== findRoot.call(this));
+        if (needsRouteRemoval) {
+          // But we've already accounted for our routes with the `treeForEngine` hook.
+          var engineJSTreeWithoutRoutes = new DependencyFunnel(engineJSTree, {
+            exclude: true,
+            entry: this.name+'/routes.js',
+            external: ['ember-engines/routes']
+          });
+
+          engineJSTree = engineJSTreeWithoutRoutes;
+        }
 
         // Move the Engine tree to `modules`
         engineJSTree = new Funnel(engineJSTree, {
@@ -435,20 +441,25 @@ module.exports = {
         var vendorJSTree = buildVendorJSTree.call(this, vendorTree);
         var vendorCSSTree = buildVendorCSSTree.call(this, vendorTree);
         var externalTree = new Funnel(vendorTree, {
-          srcDir: 'vendor',
-          allowEmpty: true
+          include: ['vendor/**/*.*']
         });
+        var engineAppTree = buildEngineJSTree.call(this);
 
-        var engineJSTree = buildEngineJSTreeWithoutRoutes.call(this);
+        // Splice out the routes.js file which we pushed into the host application.
+        var engineAppTreeWithoutRoutes = new DependencyFunnel(engineAppTree, {
+          exclude: true,
+          entry: this.name+'/routes.js',
+          external: ['ember-engines/routes']
+        });
 
         // If babel options aren't defined, we need to transpile the modules.
         if (!this.options || !this.options.babel) {
-          engineJSTree = processBabel(engineJSTree);
+          engineAppTreeWithoutRoutes = processBabel(engineAppTreeWithoutRoutes);
           vendorJSTree = processBabel(vendorJSTree);
         }
 
         // Concatenate all of the engine's JavaScript into a single file.
-        var concatEngineTree = concat(engineJSTree, {
+        var concatEngineTree = concat(engineAppTreeWithoutRoutes, {
           allowNone: true,
           inputFiles: ['**/*.js'],
           outputFile: 'engines-dist/' + this.name + '/assets/engine.js'


### PR DESCRIPTION
This reverts commit a7aae6aba7cf555959bc2cfb5bcde9e9fabea331. It also fixes https://github.com/ember-engines/engine-testing/pull/5

Keeping this in my back pocket, seeing if there is an obvious fix-forward. Also this implies that our test setup at current for `ember-engines` is not catching build errors.