### PR TITLE
Warn when `app.import` is used.

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -311,7 +311,22 @@ module.exports = {
           `this.parent`.
          */
         if (originalIncluded) {
-          originalIncluded.call(this, originalFindHost.call(this));
+          var ui = this.ui;
+          var name = this.name;
+          var host = originalFindHost.call(this);
+          var originalHostImport = host.import;
+          var customHost = Object.create(host);
+          customHost.import = function() {
+            var stack = (new Error()).stack;
+            ui.writeWarnLine('`app.import` should be avoided and `this.import` should be used instead. ' +
+                             'Using `app.import` forces the asset in question to be hoisted in all scenarios (' +
+                             'regardless of `lazyLoading` flag).\n\n  Import performed on `' + name + '`\'s `app` argument at:\n\n  ' +
+                             stack + '\n'
+                            );
+            return originalHostImport.apply(this, arguments);
+          };
+
+          originalIncluded.call(this, customHost);
         }
 
         this.eachAddonInvoke('included', [this]);


### PR DESCRIPTION
Adds a warning to the console that looks like:

```
WARNING: `app.import` should be avoided and `this.import` should be used instead. Using `app.import` forces the asset in question to be hoisted in all scenarios (regardless of `lazyLoading` flag).

  Import performed on `tree-invocation-order`'s `app` argument at:

  Error
    at EmberApp.customHost.import (/Users/rjackson/src/open-source/ember-engines/lib/engine-addon.js:320:26)
    at Class.included (/Users/rjackson/src/open-source/engine-testing/lib/tree-invocation-order/index.js:20:15)
    at Class.superWrapper [as included] (/Users/rjackson/src/open-source/engine-testing/node_modules/core-object/lib/assign-properties.js:34:20)
    at Class.included (/Users/rjackson/src/open-source/ember-engines/lib/engine-addon.js:329:28)
    at EmberApp.<anonymous> (/Users/rjackson/src/open-source/engine-testing/node_modules/ember-cli/lib/broccoli/ember-app.js:488:15)
    at Array.filter (native)
    at EmberApp._notifyAddonIncluded (/Users/rjackson/src/open-source/engine-testing/node_modules/ember-cli/lib/broccoli/ember-app.js:483:45)
    at new EmberApp (/Users/rjackson/src/open-source/engine-testing/node_modules/ember-cli/lib/broccoli/ember-app.js:140:8)
    at module.exports (/Users/rjackson/src/open-source/engine-testing/ember-cli-build.js:6:13)
    at Builder.setupBroccoliBuilder (/Users/rjackson/src/open-source/engine-testing/node_modules/ember-cli/lib/models/builder.js:54:19)
```