### PR TITLE
Ensure `preprocessTree` / `postprocessTree` are invoked properly for lazy engine styles.

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -228,6 +228,10 @@ var buildCompleteJSTree = memoize(function buildCompleteJSTree() {
   );
 });
 
+var buildEngineStyleTree = memoize(function buildEngineStyleTree() {
+  return this._treeFor('addon-styles');
+});
+
 module.exports = {
   extend: function(options) {
     var originalInit = options.init || function() { this._super.init.apply(this, arguments); };
@@ -362,7 +366,7 @@ module.exports = {
 
         // NOT LAZY LOADING!
         // This is the scenario where we want to act like an addon.
-        var engineCSSTree = this._treeFor('addon-styles');
+        var engineCSSTree = buildEngineStyleTree.call(this);
         var compiledEngineCSSTree = this.compileStyles(engineCSSTree);
 
         // If any of this engines ancestors are lazy we need to
@@ -396,7 +400,7 @@ module.exports = {
         var engineStylesOutputDir = 'engines-dist/' + this.name + '/assets/';
 
         // Get base styles tree.
-        var engineStylesTree = this._treeFor('addon-styles');
+        var engineStylesTree = buildEngineStyleTree.call(this);
 
         var primaryStyleTree = null;
         if (engineStylesTree) {

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -1,6 +1,6 @@
 var Funnel = require('broccoli-funnel');
 var merge = require('lodash/merge');
-var mergeTrees = require('broccoli-merge-trees');
+var mergeTrees = require('ember-cli/lib/broccoli/merge-trees');
 var existsSync = require('exists-sync');
 var fs = require('fs');
 var path = require('path');

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -13,6 +13,9 @@ var defaultsDeep = require('lodash.defaultsdeep');
 var calculateCacheKeyForTree = require('calculate-cache-key-for-tree');
 var Addon = require('ember-cli/lib/models/addon');
 var memoize = require('./utils/memoize');
+var p = require('ember-cli-preprocess-registry/preprocessors');
+var preprocessJs = p.preprocessJs;
+var preprocessCss = p.preprocessCss;
 
 // required until stable version of ember-cli includes
 // https://github.com/ember-cli/rfcs/pull/90
@@ -166,10 +169,6 @@ var buildEngineJSTreeWithoutRoutes = memoize(function buildEngineJSTreeWithoutRo
     entry: this.name + '/routes.js',
     external: ['ember-engines/routes']
   });
-});
-
-var buildEngineCSSTree = memoize(function buildEngineCSSTree() {
-  return this.compileStyles(this._treeFor('addon-styles'));
 });
 
 var buildVendorJSWithImports = memoize(function buildVendorJSWithImports(concatTranspiledVendorJSTree) {
@@ -358,14 +357,15 @@ module.exports = {
 
       // Replace `treeForAddon` so that we control how this engine gets built.
       // We may or may not want it to be combined like a default addon.
-      this.treeForAddon = function(engineSourceTree) {
+      this.treeForAddon = function() {
         if (this.lazyLoading === true) { return; }
 
         // NOT LAZY LOADING!
         // This is the scenario where we want to act like an addon.
-        var engineCSSTree = buildEngineCSSTree.call(this);
+        var engineCSSTree = this._treeFor('addon-styles');
+        var compiledEngineCSSTree = this.compileStyles(engineCSSTree);
 
-        // If this engine is lazy or any of its parents are lazy we need to
+        // If any of this engines ancestors are lazy we need to
         // remove its routes, because we've already accounted for our routes
         // with the `treeForEngine` hook.
         var engineJSTree = this._hasLazyAncestor ?
@@ -387,8 +387,74 @@ module.exports = {
         return mergeTrees([
           externalTree,
           engineJSTree,
-          engineCSSTree
+          compiledEngineCSSTree
         ].filter(Boolean), { overwrite: true });
+      };
+
+      this.compileLazyEngineStyles = function compileLazyEngineStyles(vendorTree, externalTree) {
+        var vendorCSSTree = buildVendorCSSTree.call(this, vendorTree);
+        var engineStylesOutputDir = 'engines-dist/' + this.name + '/assets/';
+
+        // Get base styles tree.
+        var engineStylesTree = this._treeFor('addon-styles');
+
+        var primaryStyleTree = null;
+        if (engineStylesTree) {
+          var preprocessedEngineStylesTree;
+          // `_addonPreprocessTree` was added in Ember 2.12 to ensure
+          // addons had preprocessTree / postprocessTree invoked properly
+          // this emulates the normal behavior before and after that version
+          if (this._addonPreprocessTree) {
+            preprocessedEngineStylesTree = this._addonPreprocessTree('css', engineStylesTree);
+          } else {
+            // Ember CLI < 2.12 does not support preprocessTree on addons
+            preprocessedEngineStylesTree = engineStylesTree;
+          }
+
+          var processedEngineStylesTree = preprocessCss(preprocessedEngineStylesTree, '/', '/', {
+            outputPaths: { 'addon':  engineStylesOutputDir + 'engine.css' },
+            registry: this.registry
+          });
+
+          // Move styles tree into the correct place.
+          // `**/*.css` all gets merged.
+          primaryStyleTree = concat(processedEngineStylesTree, {
+            allowNone: true,
+            inputFiles: ['**/*.css'],
+            outputFile: engineStylesOutputDir + 'engine.css'
+          });
+        }
+
+        var concatVendorCSSTree = concat(vendorCSSTree, {
+          allowNone: true,
+          inputFiles: ['**/*.css'],
+          outputFile: engineStylesOutputDir + 'engine-vendor.css'
+        });
+
+        var concatMergedVendorCSSTree = mergeTrees([concatVendorCSSTree, externalTree]);
+
+        // So, this is weird, but imports are processed in order.
+        // This gives the chance for somebody to prepend onto the vendor files.
+        var vendorCSSImportTree = buildVendorCSSWithImports.call(this, concatMergedVendorCSSTree);
+
+        var mergedVendorCSSWithImportAndEngineStylesTree = mergeTrees(
+          [vendorCSSImportTree, primaryStyleTree].filter(Boolean),
+          { overwrite: true }
+        );
+
+        var combinedProcessedStylesTree = new Funnel(mergedVendorCSSWithImportAndEngineStylesTree, {
+          srcDir: 'engines-dist/',
+          destDir: 'engines-dist/'
+        });
+
+        var finalStylesTree;
+        if (this._addonPostprocessTree) {
+          finalStylesTree = this._addonPostprocessTree('css', combinedProcessedStylesTree);
+        } else {
+          finalStylesTree = combinedProcessedStylesTree;
+        }
+
+        return finalStylesTree;
       };
 
       // We want to do the default `treeForPublic` behavior if we're not a lazy loading engine.
@@ -406,21 +472,15 @@ module.exports = {
         // LAZY LOADING!
         // But we have to implement everything manually for the lazy loading scenario.
 
-        // Get base styles tree.
-        var engineStylesTree = buildEngineCSSTree.call(this);
+        var vendorTree = buildVendorTree.call(this);
+        var vendorJSTree = buildVendorJSTree.call(this, vendorTree);
+        var externalTree = new Funnel(vendorTree, {
+          srcDir: 'vendor',
+          destDir: 'vendor',
+          allowEmpty: true
+        });
 
-        // Move styles tree into the correct place.
-        // `**/*.css` all gets merged.
-        // The addon.css file has already been renamed to match `this.name`.
-        // All we need to do is concatenate it down.
-        var primaryStyleTree;
-        if (engineStylesTree) {
-          primaryStyleTree = concat(engineStylesTree, {
-            allowNone: true,
-            inputFiles: ['**/*.css'],
-            outputFile: 'engines-dist/' + this.name + '/assets/engine.css'
-          });
-        }
+        var finalStylesTree = this.compileLazyEngineStyles(vendorTree, externalTree);
 
         // Move the public tree. It is already all in a folder named `this.name`
         var publicResult = originalTreeForPublic.apply(this, arguments);
@@ -445,15 +505,6 @@ module.exports = {
           destDir: 'engines-dist/' + this.name
         });
         var addonsEnginesPublicTreesMerged = mergeTrees([childLazyEngines, childAddonsPublicTreesRelocated], { overwrite: true });
-
-        var vendorTree = buildVendorTree.call(this);
-        var vendorJSTree = buildVendorJSTree.call(this, vendorTree);
-        var vendorCSSTree = buildVendorCSSTree.call(this, vendorTree);
-        var externalTree = new Funnel(vendorTree, {
-          srcDir: 'vendor',
-          destDir: 'vendor',
-          allowEmpty: true
-        });
 
         var engineJSTree = buildEngineJSTreeWithoutRoutes.call(this);
 
@@ -483,18 +534,6 @@ module.exports = {
         // This gives the chance for somebody to prepend onto the vendor files.
         var vendorJSImportTree = buildVendorJSWithImports.call(this, concatMergedVendorJSTree);
 
-        var concatVendorCSSTree = concat(vendorCSSTree, {
-          allowNone: true,
-          inputFiles: ['**/*.css'],
-          outputFile: 'engines-dist/' + this.name + '/assets/engine-vendor.css'
-        });
-
-        var concatMergedVendorCSSTree = mergeTrees([concatVendorCSSTree, externalTree]);
-
-        // So, this is weird, but imports are processed in order.
-        // This gives the chance for somebody to prepend onto the vendor files.
-        var vendorCSSImportTree = buildVendorCSSWithImports.call(this, concatMergedVendorCSSTree);
-
         var otherAssets;
         if (this.otherAssets) {
           otherAssets = this.otherAssets();
@@ -506,8 +545,7 @@ module.exports = {
             publicRelocated,
             addonsEnginesPublicTreesMerged,
             otherAssets,
-            vendorCSSImportTree,
-            primaryStyleTree,
+            finalStylesTree,
             vendorJSImportTree,
             concatEngineTree
           ].filter(Boolean),

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -373,9 +373,9 @@ module.exports = {
         var engineCSSTree = buildEngineStyleTree.call(this);
         var compiledEngineCSSTree = this.compileStyles(engineCSSTree);
 
-        // If any of this engines ancestors are lazy we need to
-        // remove its routes, because we've already accounted for our routes
-        // with the `treeForEngine` hook.
+        // If any of this engine's ancestors are lazy we need to
+        // remove the engine's routes file, because we've already accounted
+        // for our route map file with the `treeForEngine` hook.
         var engineJSTree = this._hasLazyAncestor ?
           buildEngineJSTreeWithoutRoutes.call(this) :
           buildEngineJSTree.call(this);

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -258,6 +258,10 @@ module.exports = {
 
       var result = originalInit.apply(this, arguments);
 
+      if (!this._addonPreprocessTree && this._addonPostprocessTree) {
+        throw new Error('ember-engines@0.5 requires ember-cli@2.12, please update your ember-cli version.');
+      }
+
       // Require that the user specify a lazyLoading property.
       if (!('lazyLoading' in this)) {
         this.ui.writeDeprecateLine(this.pkg.name + ' engine must specify the `lazyLoading` property to `true` or `false` as to whether the engine should be lazily loaded.');
@@ -399,21 +403,12 @@ module.exports = {
         var vendorCSSTree = buildVendorCSSTree.call(this, vendorTree);
         var engineStylesOutputDir = 'engines-dist/' + this.name + '/assets/';
 
-        // Get base styles tree.
+        // Get base styles tree from `this._treeFor('addon-styles')`
         var engineStylesTree = buildEngineStyleTree.call(this);
 
         var primaryStyleTree = null;
         if (engineStylesTree) {
-          var preprocessedEngineStylesTree;
-          // `_addonPreprocessTree` was added in Ember 2.12 to ensure
-          // addons had preprocessTree / postprocessTree invoked properly
-          // this emulates the normal behavior before and after that version
-          if (this._addonPreprocessTree) {
-            preprocessedEngineStylesTree = this._addonPreprocessTree('css', engineStylesTree);
-          } else {
-            // Ember CLI < 2.12 does not support preprocessTree on addons
-            preprocessedEngineStylesTree = engineStylesTree;
-          }
+          var preprocessedEngineStylesTree = this._addonPreprocessTree('css', engineStylesTree);
 
           var processedEngineStylesTree = preprocessCss(preprocessedEngineStylesTree, '/', '/', {
             outputPaths: { 'addon':  engineStylesOutputDir + 'engine.css' },
@@ -451,12 +446,8 @@ module.exports = {
           destDir: 'engines-dist/'
         });
 
-        var finalStylesTree;
-        if (this._addonPostprocessTree) {
-          finalStylesTree = this._addonPostprocessTree('css', combinedProcessedStylesTree);
-        } else {
-          finalStylesTree = combinedProcessedStylesTree;
-        }
+        // run post processing via the `postprocessTree` hook on the final output
+        var finalStylesTree = this._addonPostprocessTree('css', combinedProcessedStylesTree);
 
         return finalStylesTree;
       };

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ember-ajax": "^2.0.1",
     "ember-blog": "file:./tests/dummy/lib/ember-blog",
     "ember-chat": "file:./tests/dummy/lib/ember-chat",
-    "ember-cli": "^2.7.0",
+    "ember-cli": "github:ember-cli/ember-cli#canary",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "ember-asset-loader": "^0.2.0",
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
+    "ember-cli-preprocess-registry": "^3.0.0",
     "ember-cli-string-utils": "^1.0.0",
     "exists-sync": "0.0.3",
     "lodash": "^4.12.0",


### PR DESCRIPTION
New / tweaked styles pipeline is:

1. Invoke `preprocessTree` on all of the engines dependencies, with the raw `addon/styles` tree.
2. Process the raw tree through all the preprocessors setup in the registry.
3. Concat `**/*.css` from the result of 2 into `engine.css`
4. Concat vendor styles (dependent addons' `addon-styles` trees) into `engine-vendor.css`
5. Process `app.import`'s related to styles.
6. Invoke `postprocessTree` on all of the engines dependencies, with the final combined output of 3, 4, and 5.

Fixes #322 