### PR TITLE
Fix typo in component integration test example

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,7 +628,7 @@ following would be the setup to test such component from the host app:
 ```js
 // host-app/tests/integration/components/date-picker-test.js
 
-import { moduleForComponent, skip } from 'ember-qunit';
+import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Resolver from 'ember-engines/resolver';
 


### PR DESCRIPTION
Fixes a typo. `skip` -> `test`

`skip` is not used in the example snippet but `test` is.