### PR TITLE
Ember 2.12: Use factoryFor instead of deprecated _lookupFactory

### DIFF
--- a/addon/-private/router-ext.js
+++ b/addon/-private/router-ext.js
@@ -115,7 +115,7 @@ Router.reopen({
     seen[routeName] = true;
 
     if (!handler) {
-      const DefaultRoute = routeOwner._lookupFactory('route:basic');
+      const DefaultRoute = routeOwner.factoryFor('route:basic').class;
 
       routeOwner.register(fullRouteName, DefaultRoute.extend());
       handler = routeOwner.lookup(fullRouteName);


### PR DESCRIPTION
Ember 2.12 deprecates `_lookupFactory()` and adds `factoryFor()`.

Because ember-engines 0.5.x targets Ember 2.12 and newer, this commit does not provide a fallback to `_lookupFactory()` for older versions of Ember.

This change mirrors its counterpart in https://github.com/emberjs/ember.js/commit/eeb9175747ebf1cedf5de9541ac6d552b4a51707 , so even though I don't have a complete understanding of Ember internals, I believe this change is correct.
