### PR TITLE
Updated dependancies to show version of EmberCLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ being developed against the [master branch of
 Ember](https://github.com/emberjs/ember.js). This branch includes experimental
 lazy-loading features and should not be considered stable.
 
-v0.5 of this addon is being developed to be compatible with v2.12.x of Ember and v2.12.x of EmberCLI 
+v0.5 of this addon is being developed to be compatible with v2.12.x of both Ember and EmberCLI. 
 
 [v0.4 of this addon](https://github.com/ember-engines/ember-engines/tree/v0.4.0)
-is being developed to be compatible with v2.10.x of Ember
+is being developed to be compatible with v2.10.x of Ember.
 
 The [v0.3 branch of this addon](https://github.com/ember-engines/ember-engines/tree/v0.3)
 is being developed to be compatible with v2.8.x of Ember. This is the first

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ being developed against the [master branch of
 Ember](https://github.com/emberjs/ember.js). This branch includes experimental
 lazy-loading features and should not be considered stable.
 
-v0.5 of this addon is being developed to be compatible with v2.12.x of Ember.
+v0.5 of this addon is being developed to be compatible with EmberCLI v2.12.x
 
 [v0.4 of this addon](https://github.com/ember-engines/ember-engines/tree/v0.4.0)
-is being developed to be compatible with v2.10.x of Ember.
+is being developed to be compatible with EmberCLI v2.10.x.
 
 The [v0.3 branch of this addon](https://github.com/ember-engines/ember-engines/tree/v0.3)
 is being developed to be compatible with v2.8.x of Ember. This is the first

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ being developed against the [master branch of
 Ember](https://github.com/emberjs/ember.js). This branch includes experimental
 lazy-loading features and should not be considered stable.
 
-v0.5 of this addon is being developed to be compatible with EmberCLI v2.12.x
+v0.5 of this addon is being developed to be compatible with v2.12.x of Ember and v2.12.x of EmberCLI 
 
 [v0.4 of this addon](https://github.com/ember-engines/ember-engines/tree/v0.4.0)
-is being developed to be compatible with EmberCLI v2.10.x.
+is being developed to be compatible with v2.10.x of Ember
 
 The [v0.3 branch of this addon](https://github.com/ember-engines/ember-engines/tree/v0.3)
 is being developed to be compatible with v2.8.x of Ember. This is the first


### PR DESCRIPTION
I was confused a little by the talking just about Ember. Is there also a dependency on a version of emberJS?