### PR TITLE
Ensure app/styles in child addons of lazy engines functions properly.

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -218,7 +218,17 @@ var buildCompleteJSTree = memoize(function buildCompleteJSTree() {
 });
 
 var buildEngineStyleTree = memoize(function buildEngineStyleTree() {
-  return this._treeFor('addon-styles');
+  // get engines own addon-styles tree
+  var engineStylesTrees = [].concat(
+    this.eachAddonInvoke('treeFor', ['styles']),
+    this._treeFor('addon-styles')
+  ).filter(Boolean);
+
+  if (engineStylesTrees.length > 1) {
+    return mergeTrees(engineStylesTrees, { overwrite: true });
+  } else {
+    return engineStylesTrees[0];
+  }
 });
 
 module.exports = {
@@ -390,7 +400,7 @@ module.exports = {
         var vendorCSSTree = buildVendorCSSTree.call(this, vendorTree);
         var engineStylesOutputDir = 'engines-dist/' + this.name + '/assets/';
 
-        // Get base styles tree from `this._treeFor('addon-styles')`
+        // get engines own addon-styles tree
         var engineStylesTree = buildEngineStyleTree.call(this);
 
         var primaryStyleTree = null;
@@ -686,6 +696,7 @@ module.exports = {
       var trees;
       if (
         (name === 'app') ||
+        (name === 'styles') ||
         (name === 'addon' && this.lazyLoading === true) ||
         (name === 'public' && this.lazyLoading === true)
       ) {


### PR DESCRIPTION
Previously, if a lazy engine includes `app/styles` or any of its child addons include `app/styles` those styles were all being hoisted to the top level project's CSS assets.

This change handles the `styles` tree by ensuring that when the consuming app asks for `styles` tree we do not return one **AND** ensures that we do include `app/styles` in our custom build pipeline.

https://github.com/ember-engines/engine-testing/pull/12 was used to test this...