### PR TITLE
Fix the build.

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -113,13 +113,7 @@ var buildVendorJSTree = memoize(function buildVendorJSTree(vendorTree) {
     exclude: ['vendor/**/*.*']
   });
 
-  var vendorJSTreeRelocated = new Funnel(vendorJSTree, {
-    srcDir: 'modules',
-    destDir: '/',
-    allowEmpty: true
-  });
-
-  return vendorJSTreeRelocated;
+  return vendorJSTree;
 });
 
 var buildVendorCSSTree = memoize(function buildVendorCSSTree(vendorTree) {
@@ -142,13 +136,8 @@ var buildEngineJSTree = memoize(function buildEngineJSTree() {
   var childAppTree = buildChildAppTree.call(this);
   var augmentedEngineTree = mergeTrees([configTree, childAppTree, engineSourceTree].filter(Boolean), { overwrite: true });
   var engineTree = this.compileAddon(augmentedEngineTree);
-  var engineTreeRelocated = new Funnel(engineTree, {
-    srcDir: 'modules',
-    destDir: '/',
-    allowEmpty: true
-  });
 
-  return engineTreeRelocated;
+  return engineTree;
 });
 
 var buildEngineJSTreeWithoutRoutes = memoize(function buildEngineJSTreeWithoutRoutes() {
@@ -354,10 +343,7 @@ module.exports = {
         });
 
         // They need to be in the modules directory for later processing.
-        return new Funnel(engineRoutesTree, {
-          destDir: 'modules',
-          allowEmpty: true
-        });
+        return engineRoutesTree;
       };
 
       // Replace `treeForAddon` so that we control how this engine gets built.

--- a/tests/acceptance/lazy-routeable-engine-test.js
+++ b/tests/acceptance/lazy-routeable-engine-test.js
@@ -48,10 +48,11 @@ moduleForAcceptance('Acceptance | lazy routable engine', {
 });
 
 function verifyInitialBlogRoute(assert, loadEvents, application) {
-  assert.equal(loadEvents.length, 3, 'loaded 3 assets');
+  assert.equal(loadEvents.length, 4, 'loaded 4 assets');
   assert.deepEqual(loadEvents[0].split(SEPARATORS), [ '', 'engines-dist', 'ember-blog', 'assets', 'engine-vendor.css' ], 'loaded engine vendor css');
   assert.deepEqual(loadEvents[1].split(SEPARATORS), [ '', 'engines-dist', 'ember-blog', 'assets', 'engine-vendor.js' ], 'loaded engine vendor js');
-  assert.deepEqual(loadEvents[2].split(SEPARATORS), [ '', 'engines-dist', 'ember-blog', 'assets', 'engine.js' ], 'loaded engine js');
+  assert.deepEqual(loadEvents[2].split(SEPARATORS), [ '', 'engines-dist', 'ember-blog', 'assets', 'engine.css' ], 'loaded engine css');
+  assert.deepEqual(loadEvents[3].split(SEPARATORS), [ '', 'engines-dist', 'ember-blog', 'assets', 'engine.js' ], 'loaded engine js');
 
   assert.equal(currentURL(), '/routable-engine-demo/blog/new');
 
@@ -60,14 +61,14 @@ function verifyInitialBlogRoute(assert, loadEvents, application) {
 }
 
 test('it should pause to load JS and CSS assets on deep link into a lazy Engine', function(assert) {
-  assert.expect(7);
+  assert.expect(8);
 
   visit('/routable-engine-demo/blog/new');
   andThen(() => verifyInitialBlogRoute(assert, this.loadEvents, this.application));
 });
 
 test('it should pause to load JS and CSS assets on an initial transition into a lazy Engine', function(assert) {
-  assert.expect(7);
+  assert.expect(8);
 
   visit('/routable-engine-demo');
   click('.blog-new:last');
@@ -75,7 +76,7 @@ test('it should pause to load JS and CSS assets on an initial transition into a 
 });
 
 test('it should not pause to load assets on subsequent transitions into a lazy Engine', function(assert) {
-  assert.expect(10);
+  assert.expect(11);
 
   visit('/routable-engine-demo/blog/new');
   andThen(() => verifyInitialBlogRoute(assert, this.loadEvents, this.application));
@@ -87,13 +88,13 @@ test('it should not pause to load assets on subsequent transitions into a lazy E
 
   click('.blog-new');
   andThen(() => {
-    assert.equal(this.loadEvents.length, 3, 'did not load additional assets');
+    assert.equal(this.loadEvents.length, 4, 'did not load additional assets');
     assert.equal(currentURL(), '/routable-engine-demo/blog/new');
   });
 });
 
 test('it should not pause to load assets on transition to a loaded, but not initialized instance of a lazy Engine (e.g., Engine mounted more than once)', function(assert) {
-  assert.expect(10);
+  assert.expect(11);
 
   visit('/routable-engine-demo/blog/new');
   andThen(() => verifyInitialBlogRoute(assert, this.loadEvents, this.application));
@@ -105,7 +106,7 @@ test('it should not pause to load assets on transition to a loaded, but not init
 
   click('.ember-blog-new:last');
   andThen(() => {
-    assert.equal(this.loadEvents.length, 3, 'did not load additional assets');
+    assert.equal(this.loadEvents.length, 4, 'did not load additional assets');
     assert.equal(currentURL(), '/routable-engine-demo/ember-blog/new');
   });
 });


### PR DESCRIPTION
Due to the issue reported in https://github.com/ember-cli/ember-cli/issues/6779 our CI was passing when tests were actually failing. This PR is addressing the underlying reason they were failing (as https://github.com/ember-cli/ember-cli/issues/6779 will be fixed upstream via changes in ember-cli itself).

* Remove unneeded shimming around for `modules/` paths (this was not needed in ember-cli@2.12 and actually results in no file matches in ember-cli@2.13+).
* Fix test assertions that were confirming number of asset files loaded. The changes in https://github.com/ember-engines/ember-engines/pull/336 lead to us having an actual CSS file asset also, and the tests reported `not ok` but CI still passed (so we merged the PR). This fixes the assertions, and updates to have the tests actually pass for realz.