### PR TITLE
Add `_mergeTrees` function for compat with ember-cli#master.

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -278,6 +278,7 @@ module.exports = {
         target._import = host._import;
         target._getAssetPath = host._getAssetPath;
         target.otherAssets = host.otherAssets;
+        target._mergeTrees = host._mergeTrees;
 
         // We're delegating to the upstream EmberApp behavior for eager engines.
         if (this.lazyLoading !== true) {


### PR DESCRIPTION
In https://github.com/ember-cli/ember-cli/pull/6797 (specifically https://github.com/ember-cli/ember-cli/commit/e9758ebb2b3820abb983ccb297d077e2721dc414) the implementation of `otherAssets` was updated to use `this._mergeTrees`. Unfortunately, we are overriding the method and did not also implement an `_mergeTrees` method. This caused `ember-engines` to break when used with canary versions of ember-cli.

This brings over the `_mergeTrees` function as well, so it is also present. Thus correcting the issue.