### PR TITLE
Ensure dependency styles are in same relative path as engine styles.

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -426,7 +426,7 @@ module.exports = {
         if (engineStylesTree) {
           var preprocessedEngineStylesTree = this._addonPreprocessTree('css', engineStylesTree);
 
-          var processedEngineStylesTree = preprocessCss(preprocessedEngineStylesTree, '/', '/', {
+          var processedEngineStylesTree = preprocessCss(preprocessedEngineStylesTree, /* inputPath */ '/addon/styles', /* outputPath */ '/assets', {
             outputPaths: { 'addon':  engineStylesOutputDir + 'engine.css' },
             registry: this.registry
           });

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -227,7 +227,7 @@ var buildEngineStyleTree = memoize(function buildEngineStyleTree() {
   var engineStylesTree = this._treeFor('addon-styles');
   var dependencyStyleTrees = this.eachAddonInvoke('treeFor', ['styles']);
   var dependencyStyleTree = maybeMergeTrees(dependencyStyleTrees, { overwrite: true });
-  var relocatedDependencyStyleTree, relocatedEngineStylesTree;
+  var relocatedDependencyStyleTree;
 
   // if dependency styles trees were found, relocate them to the expected
   // path (`addon/styles)
@@ -235,21 +235,12 @@ var buildEngineStyleTree = memoize(function buildEngineStyleTree() {
     relocatedDependencyStyleTree = new Funnel(dependencyStyleTree, {
       allowEmpty: true,
       srcDir: 'app/styles',
-      destDir: 'addon/styles',
+      destDir: '/',
       annotation: 'Funnel: relocate app/styles for (' + this.name + ')'
     });
   }
 
-  // if engine styles are found, relocate them to `addon/styles`
-  if (engineStylesTree) {
-    relocatedEngineStylesTree = new Funnel(engineStylesTree, {
-      allowEmpty: true,
-      destDir: 'addon/styles',
-      annotation: 'Funnel: relocate addon/styles for (' + this.name + ')'
-    });
-  }
-
-  return maybeMergeTrees([relocatedDependencyStyleTree, relocatedEngineStylesTree], { overwrite: true });
+  return maybeMergeTrees([relocatedDependencyStyleTree, engineStylesTree], { overwrite: true });
 });
 
 module.exports = {
@@ -427,7 +418,7 @@ module.exports = {
         if (engineStylesTree) {
           var preprocessedEngineStylesTree = this._addonPreprocessTree('css', engineStylesTree);
 
-          var processedEngineStylesTree = preprocessCss(preprocessedEngineStylesTree, /* inputPath */ '/addon/styles', /* outputPath */ '/assets', {
+          var processedEngineStylesTree = preprocessCss(preprocessedEngineStylesTree, /* inputPath */ '/', /* outputPath */ '/', {
             outputPaths: { 'addon':  engineStylesOutputDir + 'engine.css' },
             registry: this.registry
           });

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -206,18 +206,50 @@ var buildCompleteJSTree = memoize(function buildCompleteJSTree() {
   );
 });
 
-var buildEngineStyleTree = memoize(function buildEngineStyleTree() {
-  // get engines own addon-styles tree
-  var engineStylesTrees = [].concat(
-    this.eachAddonInvoke('treeFor', ['styles']),
-    this._treeFor('addon-styles')
-  ).filter(Boolean);
+/*
+  Small helper function to reduce extra effort when invoking
+  `mergeTrees([])` or `mergeTrees([something])`.
 
-  if (engineStylesTrees.length > 1) {
-    return mergeTrees(engineStylesTrees, { overwrite: true });
+  @param {Array} _inputTrees an array of potential trees to merge
+  @return {Tree|undefined}
+*/
+function maybeMergeTrees(_inputTrees, options) {
+  var inputTrees = _inputTrees.filter(Boolean);
+  if (inputTrees.length > 1) {
+    return mergeTrees(inputTrees, options);
   } else {
-    return engineStylesTrees[0];
+    return inputTrees[0];
   }
+}
+
+var buildEngineStyleTree = memoize(function buildEngineStyleTree() {
+  // gather engines own `addon/styles` and its dependencies `app/styles`
+  var engineStylesTree = this._treeFor('addon-styles');
+  var dependencyStyleTrees = this.eachAddonInvoke('treeFor', ['styles']);
+  var dependencyStyleTree = maybeMergeTrees(dependencyStyleTrees, { overwrite: true });
+  var relocatedDependencyStyleTree, relocatedEngineStylesTree;
+
+  // if dependency styles trees were found, relocate them to the expected
+  // path (`addon/styles)
+  if (dependencyStyleTree) {
+    relocatedDependencyStyleTree = new Funnel(dependencyStyleTree, {
+      allowEmpty: true,
+      srcDir: 'app/styles',
+      destDir: 'addon/styles',
+      annotation: 'Funnel: relocate app/styles for (' + this.name + ')'
+    });
+  }
+
+  // if engine styles are found, relocate them to `addon/styles`
+  if (engineStylesTree) {
+    relocatedEngineStylesTree = new Funnel(engineStylesTree, {
+      allowEmpty: true,
+      destDir: 'addon/styles',
+      annotation: 'Funnel: relocate addon/styles for (' + this.name + ')'
+    });
+  }
+
+  return maybeMergeTrees([relocatedDependencyStyleTree, relocatedEngineStylesTree], { overwrite: true });
 });
 
 module.exports = {

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -342,16 +342,17 @@ module.exports = {
           var host = originalFindHost.call(this);
           var originalHostImport = host.import;
           var customHost = Object.create(host);
-          customHost.import = function() {
-            var stack = (new Error()).stack;
-            ui.writeWarnLine('`app.import` should be avoided and `this.import` should be used instead. ' +
-                             'Using `app.import` forces the asset in question to be hoisted in all scenarios (' +
-                             'regardless of `lazyLoading` flag).\n\n  Import performed on `' + name + '`\'s `app` argument at:\n\n  ' +
-                             stack + '\n'
-                            );
-            return originalHostImport.apply(this, arguments);
-          };
-
+          if (!process.env.SUPPRESS_APP_IMPORT_WARNING) {
+            customHost.import = function() {
+              var stack = (new Error()).stack;
+              ui.writeWarnLine('`app.import` should be avoided and `this.import` should be used instead. ' +
+                               'Using `app.import` forces the asset in question to be hoisted in all scenarios (' +
+                               'regardless of `lazyLoading` flag).\n\n  Import performed on `' + name + '`\'s `app` argument at:\n\n  ' +
+                               stack + '\n'
+                              );
+              return originalHostImport.apply(this, arguments);
+            };
+          }
           originalIncluded.call(this, customHost);
         }
 


### PR DESCRIPTION
When we call `treeFor('addon-styles')` the tree is returned with the `addon/styles` contents in `/`, however calling `this.eachAddonInvoke('treeFor', ['styles'])` returns the contents of dependent addons' `app/styles` tree _inside_ `app/styles`.

This change ensures that our dependencies `app/styles` contents are at the same level as our own `addon/styles` (and therefore can be imported from).
