### PR TITLE
Added semicolon at end of ENV variable

### DIFF
--- a/blueprints/in-repo-engine/routable-files/lib/__name__/config/environment.js
+++ b/blueprints/in-repo-engine/routable-files/lib/__name__/config/environment.js
@@ -5,7 +5,7 @@ module.exports = function(environment) {
   var ENV = {
     modulePrefix: '<%= modulePrefix %>',
     environment: environment
-  }
+  };
 
   return ENV;
 };


### PR DESCRIPTION
Whenever I generate a new engine, I have to add this semicolon. ¯\_(ツ)_/¯