### PR TITLE
Deduplicate addons that already appear in a host

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -307,7 +307,7 @@ module.exports = {
 
       var hostIsEngine = !!host.ancestorHostAddonNames;
 
-      var addonNames = hostIsEngine ? host.ancestorHostAddonNames() : [];
+      var addonNames = hostIsEngine ? host.ancestorHostAddonNames().slice() : [];
       var queue = hostIsEngine ? host.addons.slice() : host.project.addons.slice();
 
       // Do a breadth-first walk of the addons in the host, ignoring those that

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -70,6 +70,28 @@ function findHost() {
   return app;
 }
 
+function findHostsHost() {
+  var foundHost = false;
+  var current = this;
+  var app;
+
+  // Keep iterating upward until we don't have a grandparent.
+  // Has to do this grandparent check because at some point we hit the project.
+  do {
+    if (current.lazyLoading === true) {
+      if (foundHost) {
+        return current;
+      }
+
+      foundHost = true;
+    }
+
+    app = current.app || app;
+  } while (current.parent.parent && (current = current.parent));
+
+  return foundHost && app;
+}
+
 /**
   This is an extraction of what would normally be run by the `treeFor` hook.
   Because we call it in two different places we've moved it to a utility function.
@@ -103,7 +125,7 @@ var buildExternalTree = memoize(function buildExternalTree() {
 
 var buildVendorTree = memoize(function buildVendorTree() {
   // Manually invoke the child addons addon trees.
-  var childAddonsAddonTrees = this.eachAddonInvoke('treeFor', ['addon', 'buildVendorTree']);
+  var childAddonsAddonTrees = this.nonDuplicatedAddonInvoke('treeFor', ['addon', 'buildVendorTree']);
   var childAddonsAddonTreesMerged = mergeTrees(childAddonsAddonTrees, { overwrite: true });
 
   return childAddonsAddonTreesMerged;
@@ -236,7 +258,7 @@ function maybeMergeTrees(_inputTrees, options) {
 var buildEngineStyleTree = memoize(function buildEngineStyleTree() {
   // gather engines own `addon/styles` and its dependencies `app/styles`
   var engineStylesTree = this._treeFor('addon-styles');
-  var dependencyStyleTrees = this.eachAddonInvoke('treeFor', ['styles']);
+  var dependencyStyleTrees = this.nonDuplicatedAddonInvoke('treeFor', ['styles']);
   var dependencyStyleTree = maybeMergeTrees(dependencyStyleTrees, { overwrite: true });
   var relocatedDependencyStyleTree;
 
@@ -266,6 +288,78 @@ module.exports = {
       } else {
         return calculateCacheKeyForTree(treeType, this);
       }
+    };
+
+    /**
+     * Gets a list of all the addons by name that are used by all hosts above
+     * the current host.
+     */
+    options.ancestorHostAddonNames = function() {
+      if (this._hostAddonNames) {
+        return this._hostAddonNames;
+      }
+
+      var host = findHostsHost.call(this);
+
+      if (!host) {
+        return [];
+      }
+
+      var hostIsEngine = !!host.ancestorHostAddonNames;
+
+      var addonNames = hostIsEngine ? host.ancestorHostAddonNames() : [];
+      var queue = hostIsEngine ? host.addons.slice() : host.project.addons.slice();
+
+      // Do a breadth-first walk of the addons in the host, ignoring those that
+      // have a different host (e.g., lazy engine)
+      while (queue.length) {
+        var addon = queue.pop();
+
+        if (addon.lazyLoading) { continue; }
+        if (addonNames.indexOf(addon.name) !== -1) { continue; }
+
+        addonNames.push(addon.name);
+        queue.push.apply(queue, addon.addons);
+      }
+
+      this._hostAddonNames = addonNames;
+
+      return addonNames;
+    };
+
+    /**
+     * Gets a list of addons that are not included by an ancestor host based on
+     * the addon's name.
+     */
+    options.nonDuplicatedAddons = function() {
+      if (this._nonDuplicatedAddons) {
+        return this._nonDuplicatedAddons;
+      }
+
+      var hostAddonNames = this.ancestorHostAddonNames();
+      this._nonDuplicatedAddons = this.addons.filter(function(addon) {
+        return hostAddonNames.indexOf(addon.name) === -1;
+      });
+
+      return this._nonDuplicatedAddons;
+    };
+
+    /**
+     * Similar to eachAddonInvoke, except that it does not run the method for
+     * addons that already appear in an ancestor host already. This prevents
+     * duplicate inclusion of code by child lazy engines.
+     */
+    options.nonDuplicatedAddonInvoke = function(methodName, args) {
+      this.initializeAddons();
+
+      var invokeArguments = args || [];
+      var addons = this.nonDuplicatedAddons();
+
+      return addons.map(function(addon) {
+        if (addon[methodName]) {
+          return addon[methodName].apply(addon, invokeArguments);
+        }
+      }).filter(Boolean);
     };
 
     options.init = function() {
@@ -358,7 +452,7 @@ module.exports = {
           originalIncluded.call(this, customHost);
         }
 
-        this.eachAddonInvoke('included', [this]);
+        this.nonDuplicatedAddonInvoke('included', [this]);
       };
 
       this.treeForEngine = function() {
@@ -507,7 +601,7 @@ module.exports = {
 
         // Get the child addons public trees.
         // Sometimes this will be an engine tree in which case we need to handle it differently.
-        var childAddonsPublicTrees = this.eachAddonInvoke('treeFor', ['public']);
+        var childAddonsPublicTrees = this.nonDuplicatedAddonInvoke('treeFor', ['public']);
         var childAddonsPublicTreesMerged = mergeTrees(childAddonsPublicTrees, { overwrite: true });
         var childLazyEngines = new Funnel(childAddonsPublicTreesMerged, {
           srcDir: 'engines-dist',

--- a/node-tests/acceptance/build-test.js
+++ b/node-tests/acceptance/build-test.js
@@ -10,20 +10,10 @@ const build = require('../helpers/build');
 const InRepoAddon = require('../helpers/in-repo-addon');
 const InRepoEngine = require('../helpers/in-repo-engine');
 const expectedManifests = require('../fixtures/expected-manifests');
+const matchers = require('../helpers/matchers');
 
-/**
- * Creates a regex that matches the definition for the specified module name.
- *
- * @param {String} moduleName
- * @return {RegExp}
- */
-function moduleMatcher(moduleName) {
-  return new RegExp(`define\\(['"]${moduleName}['"]`);
-}
-
-function cssCommentMatcher(comment) {
-  return new RegExp(`/\\* ${comment} \\*/`);
-}
+const moduleMatcher = matchers.module;
+const cssCommentMatcher = matchers.cssComment;
 
 describe('Acceptance', function() {
   describe('build', function() {

--- a/node-tests/acceptance/dedupe-addons-test.js
+++ b/node-tests/acceptance/dedupe-addons-test.js
@@ -6,20 +6,10 @@ const AddonTestApp = require('ember-cli-addon-tests').AddonTestApp;
 const build = require('../helpers/build');
 const InRepoAddon = require('../helpers/in-repo-addon');
 const InRepoEngine = require('../helpers/in-repo-engine');
+const matchers = require('../helpers/matchers');
 
-/**
- * Creates a regex that matches the definition for the specified module name.
- *
- * @param {String} moduleName
- * @return {RegExp}
- */
-function moduleMatcher(moduleName) {
-  return new RegExp(`define\\(['"]${moduleName}['"]`);
-}
-
-function cssCommentMatcher(comment) {
-  return new RegExp(`/\\* ${comment} \\*/`);
-}
+const moduleMatcher = matchers.module;
+const cssCommentMatcher = matchers.cssComment;
 
 describe('Acceptance', function() {
   describe('dedupe addons', function() {

--- a/node-tests/acceptance/dedupe-addons-test.js
+++ b/node-tests/acceptance/dedupe-addons-test.js
@@ -1,0 +1,260 @@
+'use strict';
+
+const co = require('co');
+const AddonTestApp = require('ember-cli-addon-tests').AddonTestApp;
+
+const build = require('../helpers/build');
+const InRepoAddon = require('../helpers/in-repo-addon');
+const InRepoEngine = require('../helpers/in-repo-engine');
+
+/**
+ * Creates a regex that matches the definition for the specified module name.
+ *
+ * @param {String} moduleName
+ * @return {RegExp}
+ */
+function moduleMatcher(moduleName) {
+  return new RegExp(`define\\(['"]${moduleName}['"]`);
+}
+
+function cssCommentMatcher(comment) {
+  return new RegExp(`/\\* ${comment} \\*/`);
+}
+
+describe('Acceptance', function() {
+  describe('dedupe addons', function() {
+    this.timeout(300000);
+
+    it('in lazy engines that are direct dependencies of the engine', co.wrap(function* () {
+      let app = new AddonTestApp();
+      let appName = 'engine-testing';
+      let engineName = 'lazy';
+      let addonName = 'nested';
+
+      yield app.create(appName, { noFixtures: true });
+      let addon = yield InRepoAddon.generate(app, addonName);
+      let engine = yield InRepoEngine.generate(app, engineName, { lazy: true });
+
+      engine.nest(addon);
+
+      addon.writeFixture({
+        app: {
+          'foo.js': `export { default } from 'nested/components/foo';`
+        },
+        addon: {
+          styles: {
+            'addon.css': `/* ${addonName}.css */`
+          },
+          components: {
+            'foo.js': `export default {}`
+          },
+          templates: {
+            components: {
+              'foo.hbs': `<h1>foo</h1>`
+            }
+          }
+        },
+        public: {
+          'some-file.txt': `some file`
+        }
+      });
+
+      let output = yield build(app);
+
+      // Verify all the files are in the host's assets
+      output.contains(`assets/${appName}.js`, moduleMatcher(`${appName}/foo`));
+      output.contains('nested/some-file.txt');
+      output.contains('assets/vendor.js', moduleMatcher(`${addonName}/components/foo`));
+      output.contains('assets/vendor.js', moduleMatcher(`${addonName}/templates/components/foo`));
+      output.contains('assets/vendor.css', cssCommentMatcher(`${addonName}.css`));
+
+      // App folder should still be merged into the Engine's namespace
+      output.contains(`engines-dist/${engineName}/assets/engine.js`, moduleMatcher(`${engineName}/foo`));
+
+      // All other files should not be included
+      output.doesNotContain(`engines-dist/${engineName}/nested/some-file.txt`);
+      output.doesNotContain(`engines-dist/${engineName}/assets/engine-vendor.js`, moduleMatcher(`${addonName}/components/foo`));
+      output.doesNotContain(`engines-dist/${engineName}/assets/engine-vendor.js`, moduleMatcher(`${addonName}/templates/components/foo`));
+      output.doesNotContain(`engines-dist/${engineName}/assets/engine-vendor.css`, cssCommentMatcher(`${addonName}.css`));
+    }));
+
+    it.skip('in lazy engines that are nested dependencies of the engine', co.wrap(function* () {
+      let app = new AddonTestApp();
+      let appName = 'engine-testing';
+      let engineName = 'lazy';
+      let engineAddonName = 'addon-in-lazy';
+      let addonName = 'nested';
+
+      yield app.create(appName, { noFixtures: true });
+      let addon = yield InRepoAddon.generate(app, addonName);
+      let engine = yield InRepoEngine.generate(app, engineName, { lazy: true });
+      let engineAddon = yield engine.generateNestedAddon(engineAddonName, { lazy: true });
+
+      engineAddon.nest(addon);
+
+      addon.writeFixture({
+        app: {
+          'foo.js': `export { default } from 'nested/components/foo';`
+        },
+        addon: {
+          styles: {
+            'addon.css': `/* ${addonName}.css */`
+          },
+          components: {
+            'foo.js': `export default {}`
+          },
+          templates: {
+            components: {
+              'foo.hbs': `<h1>foo</h1>`
+            }
+          }
+        },
+        public: {
+          'some-file.txt': `some file`
+        }
+      });
+
+      let output = yield build(app);
+
+      // Verify all the files are in the host's assets
+      output.contains(`assets/${appName}.js`, moduleMatcher(`${appName}/foo`));
+      output.contains('nested/some-file.txt');
+      output.contains('assets/vendor.js', moduleMatcher(`${addonName}/components/foo`));
+      output.contains('assets/vendor.js', moduleMatcher(`${addonName}/templates/components/foo`));
+      output.contains('assets/vendor.css', cssCommentMatcher(`${addonName}.css`));
+
+      // App folder should still be merged into the Engine's namespace
+      output.contains(`engines-dist/${engineName}/assets/engine.js`, moduleMatcher(`${engineName}/foo`));
+
+      // All other files should not be included
+      output.doesNotContain(`engines-dist/${engineName}/nested/some-file.txt`);
+      output.doesNotContain(`engines-dist/${engineName}/assets/engine-vendor.js`, moduleMatcher(`${addonName}/components/foo`));
+      output.doesNotContain(`engines-dist/${engineName}/assets/engine-vendor.js`, moduleMatcher(`${addonName}/templates/components/foo`));
+      output.doesNotContain(`engines-dist/${engineName}/assets/engine-vendor.css`, cssCommentMatcher(`${addonName}.css`));
+    }));
+
+    it('in deeply nested lazy engines that appear in host application', co.wrap(function* () {
+      let app = new AddonTestApp();
+      let appName = 'engine-testing';
+      let engineName = 'lazy';
+      let nestedEngineName = 'lazy-in-lazy';
+      let addonName = 'nested';
+
+      yield app.create(appName, { noFixtures: true });
+      let addon = yield InRepoAddon.generate(app, addonName);
+      let engine = yield InRepoEngine.generate(app, engineName, { lazy: true });
+      let nestedEngine = yield engine.generateNestedEngine(nestedEngineName, { lazy: true });
+
+      nestedEngine.nest(addon);
+
+      addon.writeFixture({
+        app: {
+          'foo.js': `export { default } from 'nested/components/foo';`
+        },
+        addon: {
+          styles: {
+            'addon.css': `/* ${addonName}.css */`
+          },
+          components: {
+            'foo.js': `export default {}`
+          },
+          templates: {
+            components: {
+              'foo.hbs': `<h1>foo</h1>`
+            }
+          }
+        },
+        public: {
+          'some-file.txt': `some file`
+        }
+      });
+
+      let output = yield build(app);
+
+      // Verify all the files are in the host's assets
+      output.contains(`assets/${appName}.js`, moduleMatcher(`${appName}/foo`));
+      output.contains('nested/some-file.txt');
+      output.contains('assets/vendor.js', moduleMatcher(`${addonName}/components/foo`));
+      output.contains('assets/vendor.js', moduleMatcher(`${addonName}/templates/components/foo`));
+      output.contains('assets/vendor.css', cssCommentMatcher(`${addonName}.css`));
+
+      // App folder should still be merged into the Engine's namespace
+      output.doesNotContain(`engines-dist/${engineName}/assets/engine.js`, moduleMatcher(`${engineName}/foo`));
+      output.contains(`engines-dist/${nestedEngineName}/assets/engine.js`, moduleMatcher(`${nestedEngineName}/foo`));
+
+      // All other files should not be included
+      output.doesNotContain(`engines-dist/${engineName}/nested/some-file.txt`);
+      output.doesNotContain(`engines-dist/${engineName}/assets/engine-vendor.js`, moduleMatcher(`${addonName}/components/foo`));
+      output.doesNotContain(`engines-dist/${engineName}/assets/engine-vendor.js`, moduleMatcher(`${addonName}/templates/components/foo`));
+      output.doesNotContain(`engines-dist/${engineName}/assets/engine-vendor.css`, cssCommentMatcher(`${addonName}.css`));
+
+      output.doesNotContain(`engines-dist/${nestedEngineName}/nested/some-file.txt`);
+      output.doesNotContain(`engines-dist/${nestedEngineName}/assets/engine-vendor.js`, moduleMatcher(`${addonName}/components/foo`));
+      output.doesNotContain(`engines-dist/${nestedEngineName}/assets/engine-vendor.js`, moduleMatcher(`${addonName}/templates/components/foo`));
+      output.doesNotContain(`engines-dist/${nestedEngineName}/assets/engine-vendor.css`, cssCommentMatcher(`${addonName}.css`));
+    }));
+
+    it('in deeply nested lazy engines that appear in host lazy engine', co.wrap(function* () {
+      let app = new AddonTestApp();
+      let appName = 'engine-testing';
+      let engineName = 'lazy';
+      let nestedEngineName = 'lazy-in-lazy';
+      let addonName = 'nested';
+
+      yield app.create(appName, { noFixtures: true });
+      let engine = yield InRepoEngine.generate(app, engineName, { lazy: true });
+      let addon = yield engine.generateNestedAddon(addonName);
+      let nestedEngine = yield engine.generateNestedEngine(nestedEngineName, { lazy: true });
+
+      nestedEngine.nest(addon);
+
+      addon.writeFixture({
+        app: {
+          'foo.js': `export { default } from 'nested/components/foo';`
+        },
+        addon: {
+          styles: {
+            'addon.css': `/* ${addonName}.css */`
+          },
+          components: {
+            'foo.js': `export default {}`
+          },
+          templates: {
+            components: {
+              'foo.hbs': `<h1>foo</h1>`
+            }
+          }
+        },
+        public: {
+          'some-file.txt': `some file`
+        }
+      });
+
+      let output = yield build(app);
+
+      // Verify all the files are NOT in the host application's assets
+      output.doesNotContain(`assets/${appName}.js`, moduleMatcher(`${appName}/foo`));
+      output.doesNotContain('nested/some-file.txt');
+      output.doesNotContain('assets/vendor.js', moduleMatcher(`${addonName}/components/foo`));
+      output.doesNotContain('assets/vendor.js', moduleMatcher(`${addonName}/templates/components/foo`));
+      output.doesNotContain('assets/vendor.css', cssCommentMatcher(`${addonName}.css`));
+
+      // Verify all the files are in the host engine's assets
+      output.contains(`engines-dist/${engineName}/assets/engine.js`, moduleMatcher(`${engineName}/foo`));
+
+      output.contains(`engines-dist/${engineName}/nested/some-file.txt`);
+      output.contains(`engines-dist/${engineName}/assets/engine-vendor.js`, moduleMatcher(`${addonName}/components/foo`));
+      output.contains(`engines-dist/${engineName}/assets/engine-vendor.js`, moduleMatcher(`${addonName}/templates/components/foo`));
+      output.contains(`engines-dist/${engineName}/assets/engine-vendor.css`, cssCommentMatcher(`${addonName}.css`));
+
+
+      // All other files should not be included
+      output.contains(`engines-dist/${nestedEngineName}/assets/engine.js`, moduleMatcher(`${nestedEngineName}/foo`));
+
+      output.doesNotContain(`engines-dist/${nestedEngineName}/nested/some-file.txt`);
+      output.doesNotContain(`engines-dist/${nestedEngineName}/assets/engine-vendor.js`, moduleMatcher(`${addonName}/components/foo`));
+      output.doesNotContain(`engines-dist/${nestedEngineName}/assets/engine-vendor.js`, moduleMatcher(`${addonName}/templates/components/foo`));
+      output.doesNotContain(`engines-dist/${nestedEngineName}/assets/engine-vendor.css`, cssCommentMatcher(`${addonName}.css`));
+    }));
+  });
+});

--- a/node-tests/helpers/build.js
+++ b/node-tests/helpers/build.js
@@ -13,9 +13,15 @@ class BuildOutput {
 
   doesNotContain(file, matcher) {
     try {
-      return !this.contains(file, matcher);
+      this.contains(file, matcher);
     } catch (e) {
       return true;
+    }
+
+    if (arguments.length === 1) {
+      throw new Error(`Expected file "${file}" to NOT be found in the build output, but it was.`);
+    } else {
+      throw new Error(`Expected file "${file}" to NOT match "${matcher}", but it did.`);
     }
   }
 

--- a/node-tests/helpers/in-repo-addon.js
+++ b/node-tests/helpers/in-repo-addon.js
@@ -15,6 +15,7 @@ class InRepoAddon {
   }
 
   constructor(app, name) {
+    this.name = name;
     this.app = app;
     this.path = path.join(app.path, 'lib', name);
   }

--- a/node-tests/helpers/in-repo-addon.js
+++ b/node-tests/helpers/in-repo-addon.js
@@ -30,6 +30,35 @@ class InRepoAddon {
   writeFixture(fixture) {
     fixturify.writeSync(this.path, fixture);
   }
+
+  nest(addon) {
+    this.editPackageJSON((pkg) => {
+      pkg['ember-addon'] = pkg['ember-addon'] || {};
+      pkg['ember-addon'].paths = pkg['ember-addon'].paths || [];
+      pkg['ember-addon'].paths.push(`../${addon.name}`);
+    });
+  }
+
+  generateNestedAddon(name) {
+    // Generate another in-repo-addon at the app level...
+    let args = Array.prototype.slice.call(arguments)
+    args.unshift(this.app);
+    return InRepoAddon.generate.apply(null, args).then((addon) => {
+      // Remove the in-repo-addon from the app...
+      this.app.editPackageJSON((pkg) => {
+        pkg['ember-addon'].paths = pkg['ember-addon'].paths.filter((path) => path !== `lib/${name}`);
+      });
+
+      // Add the in-repo-addon to this engine.
+      this.editPackageJSON((pkg) => {
+        pkg['ember-addon'] = pkg['ember-addon'] || {};
+        pkg['ember-addon'].paths = pkg['ember-addon'].paths || [];
+        pkg['ember-addon'].paths.push(`../${name}`);
+      });
+
+      return addon;
+    });
+  }
 }
 
 module.exports = InRepoAddon;

--- a/node-tests/helpers/in-repo-engine.js
+++ b/node-tests/helpers/in-repo-engine.js
@@ -31,14 +31,6 @@ class InRepoEngine extends InRepoAddon {
     });
   }
 
-  nest(addon) {
-    this.editPackageJSON((pkg) => {
-      pkg['ember-addon'] = pkg['ember-addon'] || {};
-      pkg['ember-addon'].paths = pkg['ember-addon'].paths || [];
-      pkg['ember-addon'].paths.push(`../${addon.name}`);
-    });
-  }
-
   generateNestedEngine(name) {
     // Generate another in-repo-engine at the app level...
     let args = Array.prototype.slice.call(arguments)
@@ -51,37 +43,12 @@ class InRepoEngine extends InRepoAddon {
 
       // Add the in-repo-engine to this engine.
       this.editPackageJSON((pkg) => {
-        pkg['ember-addon'] = {
-          paths: [
-            `../${name}`
-          ]
-        };
+        pkg['ember-addon'] = pkg['ember-addon'] || {};
+        pkg['ember-addon'].paths = pkg['ember-addon'].paths || [];
+        pkg['ember-addon'].paths.push(`../${name}`);
       });
 
       return engine;
-    });
-  }
-
-  generateNestedAddon(name) {
-    // Generate another in-repo-addon at the app level...
-    let args = Array.prototype.slice.call(arguments)
-    args.unshift(this.app);
-    return InRepoAddon.generate.apply(null, args).then((addon) => {
-      // Remove the in-repo-addon from the app...
-      this.app.editPackageJSON((pkg) => {
-        pkg['ember-addon'].paths = pkg['ember-addon'].paths.filter((path) => path !== `lib/${name}`);
-      });
-
-      // Add the in-repo-addon to this engine.
-      this.editPackageJSON((pkg) => {
-        pkg['ember-addon'] = {
-          paths: [
-            `../${name}`
-          ]
-        };
-      });
-
-      return addon;
     });
   }
 }

--- a/node-tests/helpers/in-repo-engine.js
+++ b/node-tests/helpers/in-repo-engine.js
@@ -31,6 +31,14 @@ class InRepoEngine extends InRepoAddon {
     });
   }
 
+  nest(addon) {
+    this.editPackageJSON((pkg) => {
+      pkg['ember-addon'] = pkg['ember-addon'] || {};
+      pkg['ember-addon'].paths = pkg['ember-addon'].paths || [];
+      pkg['ember-addon'].paths.push(`../${addon.name}`);
+    });
+  }
+
   generateNestedEngine(name) {
     // Generate another in-repo-engine at the app level...
     let args = Array.prototype.slice.call(arguments)

--- a/node-tests/helpers/matchers.js
+++ b/node-tests/helpers/matchers.js
@@ -1,0 +1,24 @@
+/**
+ * Creates a regex that matches the definition for the specified module name.
+ *
+ * @param {String} moduleName
+ * @return {RegExp}
+ */
+function moduleMatcher(moduleName) {
+  return new RegExp(`define\\(['"]${moduleName}['"]`);
+}
+
+/**
+ * Creates a regex that matches a CSS comment with the specified content.
+ *
+ * @param {String} moduleName
+ * @return {RegExp}
+ */
+function cssCommentMatcher(comment) {
+  return new RegExp(`/\\* ${comment} \\*/`);
+}
+
+module.exports = {
+  module: moduleMatcher,
+  cssComment: cssCommentMatcher
+};

--- a/tests/dummy/lib/ember-blog/addon/styles/addon.css
+++ b/tests/dummy/lib/ember-blog/addon/styles/addon.css
@@ -1,0 +1,1 @@
+/* ember-blog.css */


### PR DESCRIPTION
Addressing the first part of https://github.com/ember-engines/ember-engines/issues/329.

Figuring out duplicated addons is a bit more tricky than I anticipated. Largely because `eachAddonInvoke` is essentially a depth-first walk of the addon tree, but we would want it to be breadth-first so that we know all the addons at the previous level.

Note: I added an explicit CSS file to the ember-blog engine, because the styles tree would be undefined now that we deduplicate the styles trees.

Todo:
- [x] Tests