### PR TITLE
Make the default addon tree an option

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -26,6 +26,9 @@ var DEFAULT_CONFIG = {
       css: '/assets/engine-vendor.css',
       js: '/assets/engine-vendor.js'
     }
+  },
+  trees: {
+    addon: 'addon'
   }
 };
 
@@ -126,9 +129,17 @@ var buildVendorCSSTree = memoize(function buildVendorCSSTree(vendorTree) {
 
 var buildEngineJSTree = memoize(function buildEngineJSTree() {
   var engineSourceTree;
-  var treePath = path.resolve(this.root, this.treePaths['addon']);
-  if (existsSync(treePath)) {
+  var treePath;
+  var addonTree = this.options.trees.addon;
+
+  if (typeof addonTree === 'string') {
+    treePath = path.resolve(this.root, addonTree);
+  }
+
+  if (treePath && existsSync(treePath)) {
     engineSourceTree = this.treeGenerator(treePath);
+  } else {
+    engineSourceTree = addonTree;
   }
 
   // We want the config and child app trees to be compiled with the engine source


### PR DESCRIPTION
This change fixes an issue where the treePath is hardcoded to a path instead of being configurable by the user. 

Fixes #355 