### PR TITLE
Move to ember-cli#beta channel

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ember-ajax": "^2.0.1",
     "ember-blog": "file:./tests/dummy/lib/ember-blog",
     "ember-chat": "file:./tests/dummy/lib/ember-chat",
-    "ember-cli": "github:ember-cli/ember-cli#canary",
+    "ember-cli": "2.12.0-beta.2",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",


### PR DESCRIPTION
Since the `0.5.x` series is meant to be compatible with Ember-CLI 2.12, we should move to the beta channel and unbreak the build.