### PR TITLE
Add lazy option to in-repo-engine blueprint

### DIFF
--- a/blueprints/in-repo-engine/index.js
+++ b/blueprints/in-repo-engine/index.js
@@ -14,7 +14,9 @@ module.exports = {
 
     return {
       name: name,
-      modulePrefix: name
+      modulePrefix: name,
+      hasLazyFlag: typeof options.lazy !== 'undefined',
+      isLazy: !!options.lazy
     };
   },
 
@@ -27,6 +29,11 @@ module.exports = {
         { 'routable': 'routable' },
         { 'routeless': 'routeless' }
       ]
+    },
+    {
+      name: 'lazy',
+      type: Boolean,
+      description: 'Whether this Engine should load lazily or not'
     }
   ],
 

--- a/blueprints/in-repo-engine/routable-files/lib/__name__/index.js
+++ b/blueprints/in-repo-engine/routable-files/lib/__name__/index.js
@@ -1,7 +1,9 @@
 /*jshint node:true*/
 var EngineAddon = require('ember-engines/lib/engine-addon');
 module.exports = EngineAddon.extend({
-  name: '<%= dasherizedModuleName %>',
+  name: '<%= dasherizedModuleName %>',<% if (hasLazyFlag) { %>
+
+  lazyLoading: <%= isLazy %>,<% } %>
 
   isDevelopingAddon: function() {
     return true;

--- a/blueprints/in-repo-engine/routeless-files/lib/__name__/index.js
+++ b/blueprints/in-repo-engine/routeless-files/lib/__name__/index.js
@@ -1,7 +1,9 @@
 /*jshint node:true*/
 var EngineAddon = require('ember-engines/lib/engine-addon');
 module.exports = EngineAddon.extend({
-  name: '<%= dasherizedModuleName %>',
+  name: '<%= dasherizedModuleName %>',<% if (hasLazyFlag) { %>
+
+  lazyLoading: <%= isLazy %>,<% } %>
 
   isDevelopingAddon: function() {
     return true;


### PR DESCRIPTION
This allows you to specify `--lazy` when generating an in-repo-engine. Ex:

```bash
ember generate in-repo-engine foo --lazy true
```

If the option is omitted, nothing will be set, which preserve the current default of not having a default for `lazyLoading`.