### PR TITLE
Remove Ember Try scenario for Ember 1.13

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -8,17 +8,6 @@ module.exports = {
       }
     },
     {
-      name: 'ember-1.13',
-      bower: {
-        dependencies: {
-          'ember': '~1.13.0'
-        },
-        resolutions: {
-          'ember': '~1.13.0'
-        }
-      }
-    },
-    {
       name: 'ember-release',
       bower: {
         dependencies: {


### PR DESCRIPTION
AFAIK Ember 1.13 isn't supported in any version of ember-engines.