### PR TITLE
Ensure `asset-loader` runs after `broccoli-asset-rev`

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "lodash.defaultsdeep": "^4.5.1"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "after": "broccoli-asset-rev"
   }
 }


### PR DESCRIPTION
This ensures that the asset manifest generated by the `asset-loader` will be fingerprinted by `broccoli-asset-rev`. Which, in turn, ensures that the `{app}/config/asset-manifest` meta tag's value will contain the correct fingerprinted assets. 

(I was able to successfully deploy an app with fingerprinting + async engines after applying this fix). 