### PR TITLE
Add deprecated flag to force ember-engines@0.4 styles behaviors.

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -858,7 +858,9 @@ module.exports = {
       var trees;
       if (
         (name === 'app') ||
-        (name === 'styles') ||
+          // when using deprecated 0.4 style processing, we allow the styles tree to be
+          // hoisted to the top level host
+        (this.useDeprecatedIncorrectCSSProcessing !== true && name === 'styles') ||
         (name === 'addon' && this.lazyLoading === true) ||
         (name === 'public' && this.lazyLoading === true)
       ) {

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -372,6 +372,11 @@ module.exports = {
 
       var result = originalInit.apply(this, arguments);
 
+      var useDeprecatedIncorrectCSSProcessing = this.useDeprecatedIncorrectCSSProcessing === true;
+      if (useDeprecatedIncorrectCSSProcessing) {
+        this.ui.writeDeprecateLine(this.pkg.name + ' engine has opted in to ember-engines@0.4 styles processing compatibility mode (via use of the `useDeprecatedIncorrectCSSProcessing` flag), this is deprecated and will be removed in future versions.');
+      }
+
       if (!this._addonPreprocessTree && this._addonPostprocessTree) {
         throw new Error('ember-engines@0.5 requires ember-cli@2.12, please update your ember-cli version.');
       }

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -489,6 +489,11 @@ module.exports = {
         // NOT LAZY LOADING!
         // This is the scenario where we want to act like an addon.
         var engineCSSTree = buildEngineStyleTree.call(this);
+
+        if (useDeprecatedIncorrectCSSProcessing) {
+          engineCSSTree = this._treeFor('addon-styles');
+        }
+
         var compiledEngineCSSTree = this.compileStyles(engineCSSTree);
 
         // If any of this engine's ancestors are lazy we need to
@@ -517,7 +522,41 @@ module.exports = {
         ].filter(Boolean), { overwrite: true });
       };
 
-      this.compileLazyEngineStyles = function compileLazyEngineStyles(vendorTree, externalTree) {
+      // this method implements ember-engines@0.4 semantics around
+      // styles for lazy engines, it is fundamentally flawed (which
+      // is why the non-deprecated path is very different).
+      //
+      // this should be removed prior to ember-engines@0.6 final release
+      function deprecatedCompileLazyStyles(vendorTree, externalTree) {
+        var vendorCSSTree = buildVendorCSSTree.call(this, vendorTree);
+        var engineStylesTree = this.compileStyles(this._treeFor('addon-styles'));
+        var engineStylesOutputDir = 'engines-dist/' + this.name + '/assets/';
+
+        var primaryStyleTree = null;
+        if (engineStylesTree) {
+
+          // Move styles tree into the correct place.
+          // `**/*.css` all gets merged.
+          primaryStyleTree = concat(engineStylesTree, {
+            allowNone: true,
+            inputFiles: ['**/*.css'],
+            outputFile: engineStylesOutputDir + 'engine.css'
+          });
+        }
+
+        var concatVendorCSSTree = concat(vendorCSSTree, {
+          allowNone: true,
+          inputFiles: ['**/*.css'],
+          outputFile: engineStylesOutputDir + 'engine-vendor.css'
+        });
+
+        var concatMergedVendorCSSTree = mergeTrees([concatVendorCSSTree, externalTree]);
+        var vendorCSSImportTree = buildVendorCSSWithImports.call(this, concatMergedVendorCSSTree);
+
+        return mergeTrees([primaryStyleTree, vendorCSSImportTree].filter(Boolean));
+      }
+
+      function compileLazyEngineStyles(vendorTree, externalTree) {
         var vendorCSSTree = buildVendorCSSTree.call(this, vendorTree);
         var engineStylesOutputDir = 'engines-dist/' + this.name + '/assets/';
 
@@ -568,7 +607,9 @@ module.exports = {
         var finalStylesTree = this._addonPostprocessTree('css', combinedProcessedStylesTree);
 
         return finalStylesTree;
-      };
+      }
+
+      this.compileLazyEngineStyles = useDeprecatedIncorrectCSSProcessing ? deprecatedCompileLazyStyles : compileLazyEngineStyles;
 
       // We want to do the default `treeForPublic` behavior if we're not a lazy loading engine.
       // If we are a lazy loading engine we now have to manually do the compilation steps for the engine.

--- a/node-tests/acceptance/deprecate-styles-flag-test.js
+++ b/node-tests/acceptance/deprecate-styles-flag-test.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const co = require('co');
+const AddonTestApp = require('ember-cli-addon-tests').AddonTestApp;
+const stripIndent = require('common-tags').stripIndent;
+
+const build = require('../helpers/build');
+const InRepoAddon = require('../helpers/in-repo-addon');
+const InRepoEngine = require('../helpers/in-repo-engine');
+const matchers = require('../helpers/matchers');
+
+const moduleMatcher = matchers.module;
+const cssCommentMatcher = matchers.cssComment;
+
+describe('Acceptance', function() {
+  describe('useDeprecatedIncorrectCSSProcessing flag', function() {
+    this.timeout(300000);
+
+    it('when enabled with lazy engines that have dependencies with app/styles', co.wrap(function* () {
+      let app = new AddonTestApp();
+      let appName = 'engine-testing';
+      let engineName = 'lazy';
+      let addonName = 'nested';
+
+      yield app.create(appName, { noFixtures: true });
+      let engine = yield InRepoEngine.generate(app, engineName, { lazy: true });
+      engine.writeFixture({
+        'index.js': stripIndent`
+          module.exports = {
+            name: '${engineName}',
+            lazyLoading: true,
+            useDeprecatedIncorrectCSSProcessing: true
+          };
+        `
+      });
+
+      let addon = yield engine.generateNestedAddon(addonName);
+
+      engine.nest(addon);
+
+      addon.writeFixture({
+        app: {
+          styles: {
+            [`${addonName}.css`]: `/* ${addonName}.css */`
+          }
+        }
+      });
+
+      let output = yield build(app);
+
+      output.contains(`assets/${addonName}.css`, cssCommentMatcher(`${addonName}.css`));
+    }));
+
+    it('when disabled with lazy engines that have dependencies with app/styles', co.wrap(function* () {
+      let app = new AddonTestApp();
+      let appName = 'engine-testing';
+      let engineName = 'lazy';
+      let addonName = 'nested';
+
+      yield app.create(appName, { noFixtures: true });
+      let engine = yield InRepoEngine.generate(app, engineName, { lazy: true });
+      let addon = yield engine.generateNestedAddon(addonName);
+
+      engine.nest(addon);
+
+      addon.writeFixture({
+        app: {
+          styles: {
+            [`${addonName}.css`]: `/* ${addonName}.css */`
+          }
+        }
+      });
+
+      let output = yield build(app);
+
+      output.contains(`engines-dist/${engineName}/assets/engine.css`, cssCommentMatcher(`${addonName}.css`));
+    }));
+  });
+});


### PR DESCRIPTION
ember-engines@0.4 had a number of flaws with its style processing. A few examples of this are:

* All engine dependencies that have `app/styles` trees were **always** hoisted to the top level host application.
* Preprocessors were being ran only for the engines own styles, but not including any of its dependencies `app/styles` (causing `@import` to work in very bizarre ways).
* `preprocessTree` / `postprocessTree` hooks were never called for styles

All of these issues have been addressed in ember-engines@0.5, and so far there are no known issues with the fixes added to 0.5 for this. Unfortunately, applications in the wild came to rely on the broken behaviors :cry:, and now have completely broke styles when upgrading to ember-engines@0.5. 

This PR adds a mechanism for applications to leverage which allows a per-engine opt-out of the new styles behaviors. When enabled, this flag causes the engine to behave nearly identically to ember-engines@0.4 (WRT styles).

Usage of this flag would look like:

```js
const EngineAddon = require('ember-engines/lib/engine-addon');

module.exports = EngineAddon.extend({
  name: 'ember-blog',
  useDeprecatedIncorrectCSSProcessing: true
});
```

*Note:* Enabling this flag, will emit a console warning (for each engine that it is enabled on).  This backwards compatibility shim will be removed prior to ember-engines@0.6.

---

For ease in reviewing, the primary changes from 0.4 to 0.5 on the styles front were:

* https://github.com/ember-engines/ember-engines/pull/324
* https://github.com/ember-engines/ember-engines/pull/336
* https://github.com/ember-engines/ember-engines/pull/345

This PR is intending to nullify all three of those PR's when the flag is enabled...