### PR TITLE
Change useDeprecatedIncorrectCSSProcessing to emulate 0.5.0-beta.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "4"
+  - "6"
 
 cache:
   yarn: true

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -522,46 +522,16 @@ module.exports = {
         ].filter(Boolean), { overwrite: true });
       };
 
-      // this method implements ember-engines@0.4 semantics around
-      // styles for lazy engines, it is fundamentally flawed (which
-      // is why the non-deprecated path is very different).
-      //
-      // this should be removed prior to ember-engines@0.6 final release
-      function deprecatedCompileLazyStyles(vendorTree, externalTree) {
-        var vendorCSSTree = buildVendorCSSTree.call(this, vendorTree);
-        var engineStylesTree = this.compileStyles(this._treeFor('addon-styles'));
-        var engineStylesOutputDir = 'engines-dist/' + this.name + '/assets/';
-
-        var primaryStyleTree = null;
-        if (engineStylesTree) {
-
-          // Move styles tree into the correct place.
-          // `**/*.css` all gets merged.
-          primaryStyleTree = concat(engineStylesTree, {
-            allowNone: true,
-            inputFiles: ['**/*.css'],
-            outputFile: engineStylesOutputDir + 'engine.css'
-          });
-        }
-
-        var concatVendorCSSTree = concat(vendorCSSTree, {
-          allowNone: true,
-          inputFiles: ['**/*.css'],
-          outputFile: engineStylesOutputDir + 'engine-vendor.css'
-        });
-
-        var concatMergedVendorCSSTree = mergeTrees([concatVendorCSSTree, externalTree]);
-        var vendorCSSImportTree = buildVendorCSSWithImports.call(this, concatMergedVendorCSSTree);
-
-        return mergeTrees([primaryStyleTree, vendorCSSImportTree].filter(Boolean));
-      }
-
-      function compileLazyEngineStyles(vendorTree, externalTree) {
+      this.compileLazyEngineStyles = function compileLazyEngineStyles(vendorTree, externalTree) {
         var vendorCSSTree = buildVendorCSSTree.call(this, vendorTree);
         var engineStylesOutputDir = 'engines-dist/' + this.name + '/assets/';
 
         // get engines own addon-styles tree
         var engineStylesTree = buildEngineStyleTree.call(this);
+
+        if (useDeprecatedIncorrectCSSProcessing) {
+          engineStylesTree = this._treeFor('addon-styles');
+        }
 
         var primaryStyleTree = null;
         if (engineStylesTree) {
@@ -607,9 +577,7 @@ module.exports = {
         var finalStylesTree = this._addonPostprocessTree('css', combinedProcessedStylesTree);
 
         return finalStylesTree;
-      }
-
-      this.compileLazyEngineStyles = useDeprecatedIncorrectCSSProcessing ? deprecatedCompileLazyStyles : compileLazyEngineStyles;
+      };
 
       // We want to do the default `treeForPublic` behavior if we're not a lazy loading engine.
       // If we are a lazy loading engine we now have to manually do the compilation steps for the engine.


### PR DESCRIPTION
The flag previously emulated 0.4.0, this updates the flag to emulate 0.5.0-beta.6.

The primary difference here is that https://github.com/ember-engines/ember-engines/pull/324 is now included in these changes...