### PR TITLE
Only include app/styles from dependency addons in lazy case

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -255,27 +255,6 @@ function maybeMergeTrees(_inputTrees, options) {
   }
 }
 
-var buildEngineStyleTree = memoize(function buildEngineStyleTree() {
-  // gather engines own `addon/styles` and its dependencies `app/styles`
-  var engineStylesTree = this._treeFor('addon-styles');
-  var dependencyStyleTrees = this.nonDuplicatedAddonInvoke('treeFor', ['styles']);
-  var dependencyStyleTree = maybeMergeTrees(dependencyStyleTrees, { overwrite: true });
-  var relocatedDependencyStyleTree;
-
-  // if dependency styles trees were found, relocate them to the expected
-  // path (`addon/styles)
-  if (dependencyStyleTree) {
-    relocatedDependencyStyleTree = new Funnel(dependencyStyleTree, {
-      allowEmpty: true,
-      srcDir: 'app/styles',
-      destDir: '/',
-      annotation: 'Funnel: relocate app/styles for (' + this.name + ')'
-    });
-  }
-
-  return maybeMergeTrees([relocatedDependencyStyleTree, engineStylesTree], { overwrite: true });
-});
-
 module.exports = {
   extend: function(options) {
     var originalInit = options.init || function() { this._super.init.apply(this, arguments); };
@@ -488,11 +467,7 @@ module.exports = {
 
         // NOT LAZY LOADING!
         // This is the scenario where we want to act like an addon.
-        var engineCSSTree = buildEngineStyleTree.call(this);
-
-        if (useDeprecatedIncorrectCSSProcessing) {
-          engineCSSTree = this._treeFor('addon-styles');
-        }
+        engineCSSTree = this._treeFor('addon-styles');
 
         var compiledEngineCSSTree = this.compileStyles(engineCSSTree);
 
@@ -527,10 +502,24 @@ module.exports = {
         var engineStylesOutputDir = 'engines-dist/' + this.name + '/assets/';
 
         // get engines own addon-styles tree
-        var engineStylesTree = buildEngineStyleTree.call(this);
+        engineStylesTree = this._treeFor('addon-styles');
 
-        if (useDeprecatedIncorrectCSSProcessing) {
-          engineStylesTree = this._treeFor('addon-styles');
+        // get the app styles tree from the dependent engines
+        var dependencyStyleTrees = this.nonDuplicatedAddonInvoke('treeFor', ['styles']);
+        var dependencyStyleTree = maybeMergeTrees(dependencyStyleTrees, { overwrite: true });
+        var relocatedDependencyStyleTree;
+
+        // if dependency styles trees were found, relocate them to the expected
+        // path '/' to be compiled correctly
+        if (dependencyStyleTree) {
+          relocatedDependencyStyleTree = new Funnel(dependencyStyleTree, {
+            allowEmpty: true,
+            srcDir: 'app/styles',
+            destDir: '/',
+            annotation: 'Funnel: relocate app/styles for (' + this.name + ')'
+          });
+
+          engineStylesTree = maybeMergeTrees([relocatedDependencyStyleTree, engineStylesTree], { overwrite: true });
         }
 
         var primaryStyleTree = null;


### PR DESCRIPTION
This is more like a conversation starter rather than a proper fix for a problem. The behavior I'm observing is that styles are duplicated in both engine.css and engine-vendor.css. I think this is caused, because engines, which are acting as addons (non-lazy engines), will build their own styles (everything in their addon/styles + dependency addon/styles + app/styles). When acting as lazy engines, however, it is presumed that the engine needs to build the app-namespaced styles as well (similar to what the application will do). However, they are already built as part of the addon styles and therefore duplicated.

Changing the code to only include the app/styles from the dependencies in case of a lazy engine, ensures they are not duplicated in both engine.css and engine-vendor.css.