### PR TITLE
Add broccoli-conditional-debug and begin instrumenting.

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -16,6 +16,7 @@ var memoize = require('./utils/memoize');
 var p = require('ember-cli-preprocess-registry/preprocessors');
 var preprocessJs = p.preprocessJs;
 var preprocessCss = p.preprocessCss;
+var BroccoliConditionalDebug = require('broccoli-conditional-debug');
 
 // Older versions of Ember-CLI may not have the Addon's tree cache
 var HAS_TREE_CACHE = !!Addon._treeCache;
@@ -143,10 +144,12 @@ var buildVendorJSTree = memoize(function buildVendorJSTree(vendorTree) {
 
 var buildVendorCSSTree = memoize(function buildVendorCSSTree(vendorTree) {
   // Filter out the CSS so that we can process it correctly.
-  return new Funnel(vendorTree, {
+  var vendorCSSTree = new Funnel(vendorTree, {
     include: ['**/*.css'],
     exclude: ['vendor/**/*.*']
   });
+
+  return this.debugTree(vendorCSSTree, 'vendor-style:input');
 });
 
 var buildEngineJSTree = memoize(function buildEngineJSTree() {
@@ -273,7 +276,9 @@ var buildEngineStyleTree = memoize(function buildEngineStyleTree() {
     });
   }
 
-  return maybeMergeTrees([relocatedDependencyStyleTree, engineStylesTree], { overwrite: true });
+  var combinedEngineStylesAndDependencyStylesTree = maybeMergeTrees([relocatedDependencyStyleTree, engineStylesTree], { overwrite: true });
+
+  return this.debugTree(combinedEngineStylesAndDependencyStylesTree, 'engine-style:input');
 });
 
 module.exports = {
@@ -361,6 +366,8 @@ module.exports = {
         }
       }).filter(Boolean);
     };
+
+    options.debugTree = BroccoliConditionalDebug.buildDebugCallback('ember-engines:' + options.name);
 
     options.init = function() {
       this.options = defaultsDeep(options, DEFAULT_CONFIG);
@@ -494,7 +501,7 @@ module.exports = {
           engineCSSTree = this._treeFor('addon-styles');
         }
 
-        var compiledEngineCSSTree = this.compileStyles(engineCSSTree);
+        var compiledEngineCSSTree = this.debugTree(this.compileStyles(engineCSSTree), 'styles');
 
         // If any of this engine's ancestors are lazy we need to
         // remove the engine's routes file, because we've already accounted
@@ -542,6 +549,8 @@ module.exports = {
             registry: this.registry
           });
 
+          processedEngineStylesTree = this.debugTree(processedEngineStylesTree, 'engine-style:postprocessed');
+
           // Move styles tree into the correct place.
           // `**/*.css` all gets merged.
           primaryStyleTree = concat(processedEngineStylesTree, {
@@ -549,6 +558,8 @@ module.exports = {
             inputFiles: ['**/*.css'],
             outputFile: engineStylesOutputDir + 'engine.css'
           });
+
+          primaryStyleTree = this.debugTree(primaryStyleTree, 'engine-style:output');
         }
 
         var concatVendorCSSTree = concat(vendorCSSTree, {
@@ -556,6 +567,8 @@ module.exports = {
           inputFiles: ['**/*.css'],
           outputFile: engineStylesOutputDir + 'engine-vendor.css'
         });
+
+        concatVendorCSSTree = this.debugTree(concatVendorCSSTree, 'vendor-style:pre-import');
 
         var concatMergedVendorCSSTree = mergeTrees([concatVendorCSSTree, externalTree]);
 
@@ -576,7 +589,7 @@ module.exports = {
         // run post processing via the `postprocessTree` hook on the final output
         var finalStylesTree = this._addonPostprocessTree('css', combinedProcessedStylesTree);
 
-        return finalStylesTree;
+        return this.debugTree(finalStylesTree, 'styles');
       };
 
       // We want to do the default `treeForPublic` behavior if we're not a lazy loading engine.

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "amd-name-resolver": "0.0.5",
     "broccoli-babel-transpiler": "^5.6.1",
     "broccoli-concat": "^3.0.1",
+    "broccoli-conditional-debug": "^0.5.3",
     "broccoli-dependency-funnel": "^1.0.2",
     "broccoli-file-creator": "^1.1.0",
     "broccoli-funnel": "^1.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1128,6 +1128,17 @@ broccoli-concat@^3.0.1, broccoli-concat@^3.2.2:
     lodash.uniq "^4.2.0"
     walk-sync "^0.3.1"
 
+broccoli-conditional-debug@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/broccoli-conditional-debug/-/broccoli-conditional-debug-0.5.3.tgz#43d2a93077bd9a55a1a2f6df53d6254688fc6fd4"
+  dependencies:
+    broccoli-plugin "^1.2.1"
+    fs-tree-diff "^0.5.2"
+    heimdalljs "^0.2.1"
+    heimdalljs-logger "^0.1.7"
+    minimatch "^3.0.3"
+    tree-sync "^1.2.2"
+
 broccoli-config-loader@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/broccoli-config-loader/-/broccoli-config-loader-1.0.0.tgz#c3cf5ecfaffc04338c6f1d5d38dc36baeaa131ba"
@@ -2901,8 +2912,8 @@ fs-extra@^3.0.0:
     universalify "^0.1.0"
 
 fs-promise@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/fs-promise/-/fs-promise-2.0.2.tgz#cfea45c80f46480a3fd176213fa22abc8c159521"
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/fs-promise/-/fs-promise-2.0.3.tgz#f64e4f854bcf689aa8bddcba268916db3db46854"
   dependencies:
     any-promise "^1.3.0"
     fs-extra "^2.0.0"
@@ -2950,7 +2961,7 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     mkdirp ">=0.5 0"
     rimraf "2"
 
-gauge@~2.7.1:
+gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
   dependencies:
@@ -3376,8 +3387,8 @@ is-glob@^2.0.0, is-glob@^2.0.1:
     is-extglob "^1.0.0"
 
 is-integer@^1.0.4:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/is-integer/-/is-integer-1.0.6.tgz#5273819fada880d123e1ac00a938e7172dd8d95e"
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/is-integer/-/is-integer-1.0.7.tgz#6bde81aacddf78b659b6629d629cadc51a886d5c"
   dependencies:
     is-finite "^1.0.0"
 
@@ -3977,7 +3988,7 @@ mime@1.3.4, mime@^1.2.11:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
 
-"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@~3.0.2:
+"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@~3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
   dependencies:
@@ -4168,12 +4179,12 @@ npm-run-path@^2.0.0:
     path-key "^2.0.0"
 
 npmlog@^4.0.0, npmlog@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.0.2.tgz#d03950e0e78ce1527ba26d2a7592e9348ac3e75f"
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.0.tgz#dc59bee85f64f00ed424efb2af0783df25d1c0b5"
   dependencies:
     are-we-there-yet "~1.1.2"
     console-control-strings "~1.1.0"
-    gauge "~2.7.1"
+    gauge "~2.7.3"
     set-blocking "~2.0.0"
 
 number-is-nan@^1.0.0:
@@ -5128,8 +5139,8 @@ temp@0.8.3, temp@^0.8.3:
     rimraf "~2.2.6"
 
 testem@^1.15.0:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/testem/-/testem-1.16.0.tgz#3933040b5d5b5fbdb6a2b1e7032e511b54a05867"
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/testem/-/testem-1.16.1.tgz#ef8b2c793a47082ca1791e2a49d3f22bf1d4ca28"
   dependencies:
     backbone "^1.1.2"
     bluebird "^3.4.6"
@@ -5219,7 +5230,7 @@ tough-cookie@~2.3.0:
   dependencies:
     punycode "^1.4.1"
 
-tree-sync@^1.2.1:
+tree-sync@^1.2.1, tree-sync@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/tree-sync/-/tree-sync-1.2.2.tgz#2cf76b8589f59ffedb58db5a3ac7cb013d0158b7"
   dependencies:
@@ -5432,9 +5443,13 @@ window-size@^0.1.2:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.4.tgz#f8e1aa1ee5a53ec5bf151ffa09742a6ad7697876"
 
-wordwrap@0.0.2, wordwrap@~0.0.2:
+wordwrap@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
+
+wordwrap@~0.0.2:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
Adds [broccoli-conditional-debug](https://github.com/rwjblue/broccoli-conditional-debug) as a dependency and begins instrumenting the styles portions of the build.

Once this lands, we can run a build like:

```
BROCCOLI_DEBUG=ember-engines:* ember b
```

And the instrumented trees are copied into `./DEBUG/` subfolder so that you can easily inspect them:

```
ember-engines:eager-in-eager:engine-style:input
ember-engines:eager-in-eager:styles
ember-engines:eager-in-lazy-in-lazy:engine-style:input
ember-engines:eager-in-lazy-in-lazy:styles
ember-engines:eager-in-lazy:engine-style:input
ember-engines:eager-in-lazy:styles
ember-engines:eager:engine-style:input
ember-engines:eager:styles
ember-engines:lazy-in-eager:engine-style:input
ember-engines:lazy-in-eager:engine-style:output
ember-engines:lazy-in-eager:engine-style:postprocessed
ember-engines:lazy-in-eager:styles
ember-engines:lazy-in-eager:vendor-style:input
ember-engines:lazy-in-eager:vendor-style:pre-import
ember-engines:lazy-in-lazy:engine-style:input
ember-engines:lazy-in-lazy:engine-style:output
ember-engines:lazy-in-lazy:engine-style:postprocessed
ember-engines:lazy-in-lazy:styles
ember-engines:lazy-in-lazy:vendor-style:input
ember-engines:lazy-in-lazy:vendor-style:pre-import
ember-engines:lazy:engine-style:input
ember-engines:lazy:engine-style:output
ember-engines:lazy:engine-style:postprocessed
ember-engines:lazy:styles
ember-engines:lazy:vendor-style:input
ember-engines:lazy:vendor-style:pre-import
ember-engines:tree-invocation-order:engine-style:input
ember-engines:tree-invocation-order:engine-style:output
ember-engines:tree-invocation-order:engine-style:postprocessed
ember-engines:tree-invocation-order:styles
ember-engines:tree-invocation-order:vendor-style:input
ember-engines:tree-invocation-order:vendor-style:pre-import
```

To only debug a single engine, you could run:

```
BROCCOLI_DEBUG=ember-engines:<engine name here>:* ember b
```

Which would output:

```
ember-engines:lazy-in-lazy:engine-style:input
ember-engines:lazy-in-lazy:engine-style:output
ember-engines:lazy-in-lazy:engine-style:postprocessed
ember-engines:lazy-in-lazy:styles
ember-engines:lazy-in-lazy:vendor-style:input
ember-engines:lazy-in-lazy:vendor-style:pre-import
```