### PR TITLE
Support compact re-exports

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -13,6 +13,8 @@ var calculateCacheKeyForTree = require('calculate-cache-key-for-tree');
 var Addon = require('ember-cli/lib/models/addon');
 var memoize = require('./utils/memoize');
 var p = require('ember-cli-preprocess-registry/preprocessors');
+var CompactReexports = require('babel-plugin-compact-reexports');
+var semver = require('semver');
 var preprocessCss = p.preprocessCss;
 var BroccoliDebug = require('broccoli-debug');
 
@@ -367,6 +369,22 @@ module.exports = {
 
     options.debugTree = BroccoliDebug.buildDebugCallback('ember-engines:' + options.name);
 
+    /**
+     * Determines if ember-engines should use the compact-reexports Babel plugin.
+     */
+    options.shouldCompactReExports = function() {
+      var VersionChecker = require('ember-cli-version-checker');
+      var checker = new VersionChecker(this);
+
+      var emberCliBabelVersion = this.addons.find(addon => addon.name === 'ember-cli-babel').pkg.version;
+
+      // We check the local ember-cli-babel version and the global ember-cli and
+      // loader.js versions
+      return semver.satisfies(emberCliBabelVersion, '>=6.0.0') &&
+        checker.for('ember-cli', 'npm').satisfies('>=2.13.0') &&
+        checker.for('loader.js', 'npm').satisfies('>=4.4.0');
+    };
+
     options.init = function() {
       this.options = defaultsDeep(options, DEFAULT_CONFIG);
 
@@ -389,6 +407,18 @@ module.exports = {
       // Require that the user specify a lazyLoading property.
       if (!('lazyLoading' in this)) {
         this.ui.writeDeprecateLine(this.pkg.name + ' engine must specify the `lazyLoading` property to `true` or `false` as to whether the engine should be lazily loaded.');
+      }
+
+      if (this.shouldCompactReExports()) {
+        this.ui.writeDebugLine('Compacting re-exports');
+
+        if (!this.options.babel.plugins) {
+          this.options.babel.plugins = [];
+        }
+
+        this.options.babel.plugins.push(CompactReexports);
+      } else {
+        this.ui.writeDebugLine('Not compacting re-exports');
       }
 
       // Change the host inside of engines.

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -14,7 +14,7 @@ var Addon = require('ember-cli/lib/models/addon');
 var memoize = require('./utils/memoize');
 var p = require('ember-cli-preprocess-registry/preprocessors');
 var CompactReexports = require('babel-plugin-compact-reexports');
-var semver = require('semver');
+var shouldCompactReexports = require('./utils/should-compact-reexports');
 var preprocessCss = p.preprocessCss;
 var BroccoliDebug = require('broccoli-debug');
 
@@ -369,22 +369,6 @@ module.exports = {
 
     options.debugTree = BroccoliDebug.buildDebugCallback('ember-engines:' + options.name);
 
-    /**
-     * Determines if ember-engines should use the compact-reexports Babel plugin.
-     */
-    options.shouldCompactReExports = function() {
-      var VersionChecker = require('ember-cli-version-checker');
-      var checker = new VersionChecker(this);
-
-      var emberCliBabelVersion = this.addons.find(addon => addon.name === 'ember-cli-babel').pkg.version;
-
-      // We check the local ember-cli-babel version and the global ember-cli and
-      // loader.js versions
-      return semver.satisfies(emberCliBabelVersion, '>=6.0.0') &&
-        checker.for('ember-cli', 'npm').satisfies('>=2.13.0') &&
-        checker.for('loader.js', 'npm').satisfies('>=4.4.0');
-    };
-
     options.init = function() {
       this.options = defaultsDeep(options, DEFAULT_CONFIG);
 
@@ -409,7 +393,7 @@ module.exports = {
         this.ui.writeDeprecateLine(this.pkg.name + ' engine must specify the `lazyLoading` property to `true` or `false` as to whether the engine should be lazily loaded.');
       }
 
-      if (this.shouldCompactReExports()) {
+      if (shouldCompactReexports(this)) {
         this.ui.writeDebugLine('Compacting re-exports');
 
         if (!this.options.babel.plugins) {

--- a/lib/utils/should-compact-reexports.js
+++ b/lib/utils/should-compact-reexports.js
@@ -1,0 +1,18 @@
+var VersionChecker = require('ember-cli-version-checker');
+
+/**
+ * Determines if ember-engines should use the compact-reexports Babel plugin.
+ *
+ * @private
+ * @param {EmberAddon} addon
+ * @return {Boolean}
+ */
+module.exports = function shouldCompactReexports(addon) {
+  var checker = new VersionChecker(addon);
+
+  // We check the local ember-cli-babel version and the global ember-cli and
+  // loader.js versions
+  return checker.for('ember-cli-babel', 'npm').satisfies('>=6.0.0') &&
+    checker.for('ember-cli', 'npm').satisfies('>=2.13.0') &&
+    checker.for('loader.js', 'npm').satisfies('>=4.4.0');
+};

--- a/node-tests/acceptance/build-test.js
+++ b/node-tests/acceptance/build-test.js
@@ -11,6 +11,7 @@ const expectedManifests = require('../fixtures/expected-manifests');
 const matchers = require('../helpers/matchers');
 
 const moduleMatcher = matchers.module;
+const reexportMatcher = matchers.reexport;
 const cssCommentMatcher = matchers.cssComment;
 
 describe('Acceptance', function() {
@@ -222,7 +223,7 @@ describe('Acceptance', function() {
 
       addon.writeFixture({
         app: {
-          'foo.js': '// should wind up in engine namespace'
+          'foo.js': 'export { default } from "nested/components/bar";'
         },
         addon: {
           components: {
@@ -239,7 +240,7 @@ describe('Acceptance', function() {
       let output = yield build(app);
 
       // Verify app files in addon wind up in engine's namespace in vendor.js
-      output.contains('assets/vendor.js', moduleMatcher(`${engineName}/foo`));
+      output.contains('assets/vendor.js', reexportMatcher(`${addonName}/components/bar`, `${engineName}/foo`));
 
       // Verify addon files in addon wind up in addon's namespace in vendor.js
       output.contains('assets/vendor.js', moduleMatcher(`${addonName}/components/bar`));
@@ -257,7 +258,7 @@ describe('Acceptance', function() {
 
       addon.writeFixture({
         app: {
-          'foo.js': '// should wind up in engine namespace'
+          'foo.js': 'export { default } from "nested/components/bar";'
         },
         addon: {
           components: {
@@ -274,7 +275,7 @@ describe('Acceptance', function() {
       let output = yield build(app);
 
       // Verify app files in addon wind up in engine's namespace in engine.js
-      output.contains(`engines-dist/${engineName}/assets/engine.js`, moduleMatcher(`${engineName}/foo`));
+      output.contains(`engines-dist/${engineName}/assets/engine.js`, reexportMatcher(`${addonName}/components/bar`, `${engineName}/foo`));
 
       // Verify addon files in addon wind up in addon's namespace in enigne-vendor.js
       output.contains(`engines-dist/${engineName}/assets/engine-vendor.js`, moduleMatcher(`${addonName}/components/bar`));
@@ -345,7 +346,7 @@ describe('Acceptance', function() {
       });
     }));
 
-    it('does not duplicated addons in lazy engines that appear in the host', co.wrap(function* () {
+    it('does not duplicate addons in lazy engines that appear in the host', co.wrap(function* () {
       let app = new AddonTestApp();
       let appName = 'engine-testing';
       let engineName = 'lazy';
@@ -389,7 +390,7 @@ describe('Acceptance', function() {
       output.contains('assets/vendor.css', cssCommentMatcher(`${addonName}.css`));
 
       // App folder should still be merged into the Engine's namespace
-      output.contains(`engines-dist/${engineName}/assets/engine.js`, moduleMatcher(`${engineName}/foo`));
+      output.contains(`engines-dist/${engineName}/assets/engine.js`, reexportMatcher(`${addonName}/components/foo`, `${engineName}/foo`));
 
       // All other files should not be included
       output.doesNotContain(`engines-dist/${engineName}/nested/some-file.txt`);

--- a/node-tests/acceptance/dedupe-addons-test.js
+++ b/node-tests/acceptance/dedupe-addons-test.js
@@ -9,6 +9,7 @@ const InRepoEngine = require('../helpers/in-repo-engine');
 const matchers = require('../helpers/matchers');
 
 const moduleMatcher = matchers.module;
+const reexportMatcher = matchers.reexport;
 const cssCommentMatcher = matchers.cssComment;
 
 describe('Acceptance', function() {
@@ -59,7 +60,7 @@ describe('Acceptance', function() {
       output.contains('assets/vendor.css', cssCommentMatcher(`${addonName}.css`));
 
       // App folder should still be merged into the Engine's namespace
-      output.contains(`engines-dist/${engineName}/assets/engine.js`, moduleMatcher(`${engineName}/foo`));
+      output.contains(`engines-dist/${engineName}/assets/engine.js`, reexportMatcher(`${addonName}/components/foo`, `${engineName}/foo`));
 
       // All other files should not be included
       output.doesNotContain(`engines-dist/${engineName}/nested/some-file.txt`);
@@ -169,8 +170,8 @@ describe('Acceptance', function() {
       output.contains('assets/vendor.css', cssCommentMatcher(`${addonName}.css`));
 
       // App folder should still be merged into the Engine's namespace
-      output.doesNotContain(`engines-dist/${engineName}/assets/engine.js`, moduleMatcher(`${engineName}/foo`));
-      output.contains(`engines-dist/${nestedEngineName}/assets/engine.js`, moduleMatcher(`${nestedEngineName}/foo`));
+      output.doesNotContain(`engines-dist/${engineName}/assets/engine.js`, reexportMatcher(`${addonName}/components/foo`, `${engineName}/foo`));
+      output.contains(`engines-dist/${nestedEngineName}/assets/engine.js`, reexportMatcher(`${addonName}/components/foo`, `${nestedEngineName}/foo`));
 
       // All other files should not be included
       output.doesNotContain(`engines-dist/${engineName}/nested/some-file.txt`);
@@ -230,7 +231,7 @@ describe('Acceptance', function() {
       output.doesNotContain('assets/vendor.css', cssCommentMatcher(`${addonName}.css`));
 
       // Verify all the files are in the host engine's assets
-      output.contains(`engines-dist/${engineName}/assets/engine.js`, moduleMatcher(`${engineName}/foo`));
+      output.contains(`engines-dist/${engineName}/assets/engine.js`, reexportMatcher(`${addonName}/components/foo`, `${engineName}/foo`));
 
       output.contains(`engines-dist/${engineName}/nested/some-file.txt`);
       output.contains(`engines-dist/${engineName}/assets/engine-vendor.js`, moduleMatcher(`${addonName}/components/foo`));
@@ -239,7 +240,7 @@ describe('Acceptance', function() {
 
 
       // All other files should not be included
-      output.contains(`engines-dist/${nestedEngineName}/assets/engine.js`, moduleMatcher(`${nestedEngineName}/foo`));
+      output.contains(`engines-dist/${nestedEngineName}/assets/engine.js`, reexportMatcher(`${addonName}/components/foo`, `${nestedEngineName}/foo`));
 
       output.doesNotContain(`engines-dist/${nestedEngineName}/nested/some-file.txt`);
       output.doesNotContain(`engines-dist/${nestedEngineName}/assets/engine-vendor.js`, moduleMatcher(`${addonName}/components/foo`));

--- a/node-tests/fixtures/should-compact-reexports/correct/node_modules/ember-cli-babel/package.json
+++ b/node-tests/fixtures/should-compact-reexports/correct/node_modules/ember-cli-babel/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "ember-cli-babel",
+  "version": "6.0.0"
+}

--- a/node-tests/fixtures/should-compact-reexports/correct/node_modules/ember-cli/package.json
+++ b/node-tests/fixtures/should-compact-reexports/correct/node_modules/ember-cli/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "ember-cli",
+  "version": "2.13.0"
+}

--- a/node-tests/fixtures/should-compact-reexports/correct/node_modules/loader.js/package.json
+++ b/node-tests/fixtures/should-compact-reexports/correct/node_modules/loader.js/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "loader.js",
+  "version": "4.4.0"
+}

--- a/node-tests/fixtures/should-compact-reexports/old-ember-cli-babel/node_modules/ember-cli-babel/package.json
+++ b/node-tests/fixtures/should-compact-reexports/old-ember-cli-babel/node_modules/ember-cli-babel/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "ember-cli-babel",
+  "version": "5.0.0"
+}

--- a/node-tests/fixtures/should-compact-reexports/old-ember-cli-babel/node_modules/ember-cli/package.json
+++ b/node-tests/fixtures/should-compact-reexports/old-ember-cli-babel/node_modules/ember-cli/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "ember-cli",
+  "version": "2.13.0"
+}

--- a/node-tests/fixtures/should-compact-reexports/old-ember-cli-babel/node_modules/loader.js/package.json
+++ b/node-tests/fixtures/should-compact-reexports/old-ember-cli-babel/node_modules/loader.js/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "loader.js",
+  "version": "4.4.0"
+}

--- a/node-tests/fixtures/should-compact-reexports/old-ember-cli/node_modules/ember-cli-babel/package.json
+++ b/node-tests/fixtures/should-compact-reexports/old-ember-cli/node_modules/ember-cli-babel/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "ember-cli-babel",
+  "version": "6.0.0"
+}

--- a/node-tests/fixtures/should-compact-reexports/old-ember-cli/node_modules/ember-cli/package.json
+++ b/node-tests/fixtures/should-compact-reexports/old-ember-cli/node_modules/ember-cli/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "ember-cli",
+  "version": "2.12.0"
+}

--- a/node-tests/fixtures/should-compact-reexports/old-ember-cli/node_modules/loader.js/package.json
+++ b/node-tests/fixtures/should-compact-reexports/old-ember-cli/node_modules/loader.js/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "loader.js",
+  "version": "4.4.0"
+}

--- a/node-tests/fixtures/should-compact-reexports/old-loader/node_modules/ember-cli-babel/package.json
+++ b/node-tests/fixtures/should-compact-reexports/old-loader/node_modules/ember-cli-babel/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "ember-cli-babel",
+  "version": "6.0.0"
+}

--- a/node-tests/fixtures/should-compact-reexports/old-loader/node_modules/ember-cli/package.json
+++ b/node-tests/fixtures/should-compact-reexports/old-loader/node_modules/ember-cli/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "ember-cli",
+  "version": "2.13.0"
+}

--- a/node-tests/fixtures/should-compact-reexports/old-loader/node_modules/loader.js/package.json
+++ b/node-tests/fixtures/should-compact-reexports/old-loader/node_modules/loader.js/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "loader.js",
+  "version": "4.3.0"
+}

--- a/node-tests/helpers/matchers-test.js
+++ b/node-tests/helpers/matchers-test.js
@@ -1,0 +1,77 @@
+const matchers = require('./matchers');
+const expect = require('chai').expect;
+
+describe('matchers', function() {
+  describe('module', function() {
+    it('matches module definitions for the specified name', function() {
+      const matcher = matchers.module('foo/component/bar-baz');
+
+      const inputSingleQuotes = 'define(\'foo/component/bar-baz\', [], function(){});';
+      expect(matcher.test(inputSingleQuotes)).to.be.true;
+
+      const inputDoubleQuotes = 'define("foo/component/bar-baz", [], function(){});';
+      expect(matcher.test(inputDoubleQuotes)).to.be.true;
+    });
+
+    it('does not match for non-exact module names', function() {
+      const input = 'define("foo/component/bar-baz", [], function(){});';
+
+      const longerNameMatcher = matchers.module('foo/component/bar-bazy');
+      expect(longerNameMatcher.test(input)).to.be.false;
+
+      const shorterNameMatcher = matchers.module('foo/component/bar-ba');
+      expect(shorterNameMatcher.test(input)).to.be.false;
+    });
+  });
+
+  describe('reexport', function() {
+    it('matches aliased module definitions', function() {
+      const matcher = matchers.reexport('foo/component/bar-baz', 'app/component/bar-baz');
+
+      const inputSingleQuotes = 'define.alias(\'foo/component/bar-baz\', \'app/component/bar-baz\');';
+      expect(matcher.test(inputSingleQuotes)).to.be.true;
+
+      const inputDoubleQuotes = 'define.alias("foo/component/bar-baz", "app/component/bar-baz");';
+      expect(matcher.test(inputDoubleQuotes)).to.be.true;
+    });
+
+    it('does not match improperly aliased module definitions', function() {
+      const matcher = matchers.reexport('foo/component/bar-baz', 'app/component/bar-baz');
+
+      const inputReversedAlias = 'define.alias("app/component/bar-baz", "foo/component/bar-baz");';
+      expect(matcher.test(inputReversedAlias)).to.be.false;
+
+      const inputOldAlias = 'define("foo/component/bar-baz", define.alias("foo/component/bar-baz"));';
+      expect(matcher.test(inputOldAlias)).to.be.false;
+    });
+
+    it('does not match normal module definitions', function() {
+      const matcher = matchers.reexport('foo/component/bar-baz', 'app/component/bar-baz');
+
+      const input1 = 'define("foo/component/bar-baz", [] function(){});';
+      expect(matcher.test(input1)).to.be.false;
+
+      const input2 = 'define("app/component/bar-baz", [] function(){});';
+      expect(matcher.test(input2)).to.be.false;
+    });
+  });
+
+  describe('cssComment', function() {
+    it('matches css comments', function() {
+      const matcher = matchers.cssComment('some comment');
+      const input = '/* some comment */';
+
+      expect(matcher.test(input)).to.be.true;
+    });
+
+    it('does not match improperly formatted css comments', function() {
+      const matcher = matchers.cssComment('some comment');
+
+      const inputNoSpaces = '/*some comment*/';
+      expect(matcher.test(inputNoSpaces)).to.be.false;
+
+      const inputDoubleSlash = '// some comment';
+      expect(matcher.test(inputDoubleSlash)).to.be.false;
+    });
+  });
+});

--- a/node-tests/helpers/matchers.js
+++ b/node-tests/helpers/matchers.js
@@ -9,6 +9,17 @@ function moduleMatcher(moduleName) {
 }
 
 /**
+ * Creates a regex that matches the alias definition for the specified reexport.
+ *
+ * @param {String} moduleName
+ * @param {String} alias
+ * @return {RegExp}
+ */
+function reexportMatcher(moduleName, alias) {
+  return new RegExp(`define.alias\\(['"]${moduleName}['"], ['"]${alias}['"]`);
+}
+
+/**
  * Creates a regex that matches a CSS comment with the specified content.
  *
  * @param {String} moduleName
@@ -20,5 +31,6 @@ function cssCommentMatcher(comment) {
 
 module.exports = {
   module: moduleMatcher,
+  reexport: reexportMatcher,
   cssComment: cssCommentMatcher
 };

--- a/node-tests/unit/utils/should-compact-reexports-test.js
+++ b/node-tests/unit/utils/should-compact-reexports-test.js
@@ -1,0 +1,38 @@
+const path = require('path');
+const expect = require('chai').expect;
+const shouldCompactReexports = require('../../../lib/utils/should-compact-reexports');
+
+describe('shouldCompactReexports', function() {
+  const fixturePath = path.resolve(__dirname, '../../fixtures/should-compact-reexports');
+  let addon;
+
+  function FakeAddonWithDeps() {
+    this.name = 'fake-addon-with-deps';
+    this.project = {
+      root: path.join(fixturePath, 'correct')
+    };
+  }
+
+  beforeEach(function() {
+    addon = new FakeAddonWithDeps();
+  });
+
+  it('returns true with recent versions of ember-cli-babel, ember-cli, and loader.js', function() {
+    expect(shouldCompactReexports(addon)).to.equal(true);
+  });
+
+  it('returns false when the version of ember-cli-babel is < 6.0.0', function() {
+    addon.root = path.join(fixturePath, 'old-ember-cli-babel');
+    expect(shouldCompactReexports(addon)).to.equal(false);
+  });
+
+  it('returns false when the version of ember-cli is < 2.13.0', function() {
+    addon.root = path.join(fixturePath, 'old-ember-cli')
+    expect(shouldCompactReexports(addon)).to.equal(false);
+  });
+
+  it('returns false when the version of loader.js is < 4.4.0', function() {
+    addon.root = path.join(fixturePath, 'old-loader')
+    expect(shouldCompactReexports(addon)).to.equal(false);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-preprocess-registry": "^3.0.0",
     "ember-cli-string-utils": "^1.0.0",
+    "ember-cli-version-checker": "^2.0.0",
     "eslint": "^3.19.0",
     "exists-sync": "0.0.3",
     "lodash": "^4.12.0",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   ],
   "dependencies": {
     "amd-name-resolver": "0.0.5",
+    "babel-plugin-compact-reexports": "^0.1.0",
     "broccoli-babel-transpiler": "^5.6.1",
     "broccoli-concat": "^3.0.1",
     "broccoli-debug": "^0.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -292,6 +292,10 @@ ast-types@0.8.12:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.12.tgz#a0d90e4351bb887716c83fd637ebf818af4adfcc"
 
+ast-types@0.8.15:
+  version "0.8.15"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.15.tgz#8eef0827f04dff0ec8857ba925abe3fea6194e52"
+
 ast-types@0.9.6:
   version "0.9.6"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
@@ -1026,7 +1030,7 @@ bower-endpoint-parser@0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz#00b565adbfab6f2d35addde977e97962acbcb3f6"
 
-brace-expansion@^1.0.0:
+brace-expansion@^1.0.0, brace-expansion@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.7.tgz#3effc3c50e000531fb720eaff80f0ae8ef23cf59"
   dependencies:
@@ -1177,15 +1181,16 @@ broccoli-config-replace@^1.1.2:
     debug "^2.2.0"
     fs-extra "^0.24.0"
 
-broccoli-debug@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/broccoli-debug/-/broccoli-debug-0.6.0.tgz#d8b8acdb7195edf0aaa8e0cebbb0ae2a547513e2"
+broccoli-debug@^0.6.0, broccoli-debug@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/broccoli-debug/-/broccoli-debug-0.6.1.tgz#aec612ba8e5419952f44dc78be52bfabcbc087f6"
   dependencies:
     broccoli-plugin "^1.2.1"
     fs-tree-diff "^0.5.2"
     heimdalljs "^0.2.1"
     heimdalljs-logger "^0.1.7"
     minimatch "^3.0.3"
+    sanitize-filename "^1.6.1"
     tree-sync "^1.2.2"
 
 broccoli-dependency-funnel@^1.0.2:
@@ -1361,9 +1366,10 @@ broccoli-sri-hash@^2.1.0:
     symlink-or-copy "^1.0.1"
 
 broccoli-stew@^1.2.0, broccoli-stew@^1.3.3:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/broccoli-stew/-/broccoli-stew-1.4.2.tgz#9ec4062fd7162c6026561a2fbf64558363aff8d6"
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/broccoli-stew/-/broccoli-stew-1.5.0.tgz#d7af8c18511dce510e49d308a62e5977f461883c"
   dependencies:
+    broccoli-debug "^0.6.1"
     broccoli-funnel "^1.0.1"
     broccoli-merge-trees "^1.0.0"
     broccoli-persistent-filter "^1.1.6"
@@ -1375,7 +1381,6 @@ broccoli-stew@^1.2.0, broccoli-stew@^1.3.3:
     minimatch "^3.0.2"
     resolve "^1.1.6"
     rsvp "^3.0.16"
-    sanitize-filename "^1.5.3"
     symlink-or-copy "^1.1.8"
     walk-sync "^0.3.0"
 
@@ -1468,8 +1473,8 @@ can-symlink@^1.0.0:
     tmp "0.0.28"
 
 caniuse-db@^1.0.30000639:
-  version "1.0.30000665"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000665.tgz#e84f4277935f295f546f8533cb0b410a8415b972"
+  version "1.0.30000666"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000666.tgz#951ed9f3d3bfaa08a06dafbb5089ab07cce6ab90"
 
 capture-exit@^1.1.0:
   version "1.2.0"
@@ -2141,8 +2146,8 @@ ember-cli-htmlbars-inline-precompile@^0.4.2:
     silent-error "^1.1.0"
 
 ember-cli-htmlbars@*, ember-cli-htmlbars@^1.0.0, ember-cli-htmlbars@^1.0.3:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-1.3.0.tgz#e090f011239153bf45dab29625f94a46fce205af"
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-1.3.2.tgz#906279c48be32986a3cc41e730ecc3513a34c4d1"
   dependencies:
     broccoli-persistent-filter "^1.0.3"
     ember-cli-version-checker "^1.0.2"
@@ -2299,6 +2304,13 @@ ember-cli-version-checker@^1.0.2, ember-cli-version-checker@^1.1.4, ember-cli-ve
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz#0bc2d134c830142da64bf9627a0eded10b61ae72"
   dependencies:
+    semver "^5.3.0"
+
+ember-cli-version-checker@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.0.0.tgz#e1f7d8e4cdcd752ac35f1611e4daa8836db4c4c7"
+  dependencies:
+    resolve "^1.3.3"
     semver "^5.3.0"
 
 ember-cli@2.13.1:
@@ -3746,8 +3758,8 @@ js-tokens@^3.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
 js-yaml@^3.2.5, js-yaml@^3.2.7, js-yaml@^3.5.1, js-yaml@^3.6.1:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.3.tgz#33a05ec481c850c8875929166fe1beb61c728766"
+  version "3.8.4"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.4.tgz#520b4564f86573ba96662af85a8cafa7b4b5a6f6"
   dependencies:
     argparse "^1.0.7"
     esprima "^3.1.1"
@@ -4246,10 +4258,10 @@ mime@1.3.4, mime@^1.2.11:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
 
 "minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
-    brace-expansion "^1.0.0"
+    brace-expansion "^1.1.7"
 
 minimatch@^2.0.3:
   version "2.0.10"
@@ -4828,11 +4840,20 @@ readline2@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     mute-stream "0.0.5"
 
-recast@0.10.33, recast@^0.10.10:
+recast@0.10.33:
   version "0.10.33"
   resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.33.tgz#942808f7aa016f1fa7142c461d7e5704aaa8d697"
   dependencies:
     ast-types "0.8.12"
+    esprima-fb "~15001.1001.0-dev-harmony-fb"
+    private "~0.1.5"
+    source-map "~0.5.0"
+
+recast@^0.10.10:
+  version "0.10.43"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.43.tgz#b95d50f6d60761a5f6252e15d80678168491ce7f"
+  dependencies:
+    ast-types "0.8.15"
     esprima-fb "~15001.1001.0-dev-harmony-fb"
     private "~0.1.5"
     source-map "~0.5.0"
@@ -4997,7 +5018,7 @@ resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
-resolve@^1.1.2, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.0, resolve@^1.3.2:
+resolve@^1.1.2, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.0, resolve@^1.3.2, resolve@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
   dependencies:
@@ -5026,11 +5047,11 @@ rimraf@~2.2.6:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
 
-rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.1.0, rsvp@^3.2.1, rsvp@^3.3.3, rsvp@^3.4.0:
+rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.1.0, rsvp@^3.2.1, rsvp@^3.3.3, rsvp@^3.4.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.5.0.tgz#a62c573a4ae4e1dfd0697ebc6242e79c681eaa34"
 
-rsvp@^3.0.6, rsvp@~3.0.6:
+rsvp@^3.0.17, rsvp@^3.0.6, rsvp@~3.0.6:
   version "3.0.21"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.0.21.tgz#49c588fe18ef293bcd0ab9f4e6756e6ac433359f"
 
@@ -5082,7 +5103,7 @@ sane@^1.1.1, sane@^1.6.0:
     walker "~1.0.5"
     watch "~0.10.0"
 
-sanitize-filename@^1.5.3:
+sanitize-filename@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/sanitize-filename/-/sanitize-filename-1.6.1.tgz#612da1c96473fa02dccda92dcd5b4ab164a6772a"
   dependencies:
@@ -5661,8 +5682,8 @@ uc.micro@^1.0.0, uc.micro@^1.0.1, uc.micro@^1.0.3:
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.3.tgz#7ed50d5e0f9a9fb0a573379259f2a77458d50192"
 
 uglify-js@^2.6, uglify-js@^2.7.0:
-  version "2.8.22"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.22.tgz#d54934778a8da14903fa29a326fb24c0ab51a1a0"
+  version "2.8.23"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.23.tgz#8230dd9783371232d62a7821e2cf9a817270a8a0"
   dependencies:
     source-map "~0.5.1"
     yargs "~3.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -540,6 +540,10 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-compact-reexports@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-compact-reexports/-/babel-plugin-compact-reexports-0.1.0.tgz#71e8e424cf77b07d8358d210a2c2c2a2caad0b7a"
+
 babel-plugin-constant-folding@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz#8361d364c98e449c3692bdba51eff0844290aa8e"


### PR DESCRIPTION
Fixes https://github.com/ember-engines/ember-engines/issues/265. Leverages [babel-plugin-compact-reexports](https://github.com/ember-engines/babel-plugin-compact-reexports).

TODO:
- [x] Tests

FOLLOW UPS:
- [x] Add tests for test matcher utilities
- [x] Add eslint