### PR TITLE
Use cacheKeyForTree to improve the addon dedup

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -296,12 +296,14 @@ module.exports = {
     };
 
     /**
-     * Gets a list of all the addons by name that are used by all hosts above
+     * Gets a map of all the addons that are used by all hosts above
      * the current host.
+     *
+     * The key is the name of the addon and the value is first encountered instance of this addon.
      */
-    options.ancestorHostAddonNames = function() {
-      if (this._hostAddonNames) {
-        return this._hostAddonNames;
+    options.ancestorHostAddons = function() {
+      if (this._hostAddons) {
+        return this._hostAddons;
       }
 
       var host = findHostsHost.call(this);
@@ -310,9 +312,9 @@ module.exports = {
         return [];
       }
 
-      var hostIsEngine = !!host.ancestorHostAddonNames;
+      var hostIsEngine = !!host.ancestorHostAddons;
 
-      var addonNames = hostIsEngine ? host.ancestorHostAddonNames().slice() : [];
+      var hostAddons = hostIsEngine ? Object.assign({}, host.ancestorHostAddons()) : {};
       var queue = hostIsEngine ? host.addons.slice() : host.project.addons.slice();
 
       // Do a breadth-first walk of the addons in the host, ignoring those that
@@ -321,32 +323,16 @@ module.exports = {
         var addon = queue.pop();
 
         if (addon.lazyLoading && addon.lazyLoading.enabled) { continue; }
-        if (addonNames.indexOf(addon.name) !== -1) { continue; }
 
-        addonNames.push(addon.name);
+        if (hostAddons[addon.name]) { continue; }
+
+        hostAddons[addon.name] = addon;
         queue.push.apply(queue, addon.addons);
       }
 
-      this._hostAddonNames = addonNames;
+      this._hostAddons = hostAddons;
 
-      return addonNames;
-    };
-
-    /**
-     * Gets a list of addons that are not included by an ancestor host based on
-     * the addon's name.
-     */
-    options.nonDuplicatedAddons = function() {
-      if (this._nonDuplicatedAddons) {
-        return this._nonDuplicatedAddons;
-      }
-
-      var hostAddonNames = this.ancestorHostAddonNames();
-      this._nonDuplicatedAddons = this.addons.filter(function(addon) {
-        return hostAddonNames.indexOf(addon.name) === -1;
-      });
-
-      return this._nonDuplicatedAddons;
+      return hostAddons;
     };
 
     /**
@@ -358,12 +344,31 @@ module.exports = {
       this.initializeAddons();
 
       var invokeArguments = args || [];
-      var addons = this.nonDuplicatedAddons();
+      var hostAddons = this.ancestorHostAddons();
 
-      return addons.map(function(addon) {
-        if (addon[methodName]) {
-          return addon[methodName].apply(addon, invokeArguments);
+      return this.addons.map(function(addon) {
+        if (!addon[methodName]) {
+          // no method to call
+          return;
         }
+        var hostAddon = hostAddons[addon.name];
+        if (hostAddon) {
+          switch(methodName) {
+            case 'treeFor':
+              var treeName = invokeArguments[0];
+              var hostAddonCacheKey = hostAddon.cacheKeyForTree(treeName);
+              var addonCacheKey = addon.cacheKeyForTree(treeName);
+              if (addonCacheKey != null && addonCacheKey === hostAddonCacheKey) {
+                // the addon specifies cache key and it is the same as host instance of the addon, skip the tree
+                return;
+              }
+              break;
+            default:
+              // the same addon exist in the parent as well, skip the invocation
+              return;
+          }
+        }
+        return addon[methodName].apply(addon, invokeArguments);
       }).filter(Boolean);
     };
 


### PR DESCRIPTION
Attempt to fix #416 .

The change keeps the old logic for all invocations, which are not `treeFor`. For `treeFor`, the code will consult `cacheKeyForTree` to determine whether the trees from the host addon and the engine dependency addon are the same.

There is an open question of whether finding the corresponding host addon simply based on the name is enough. The host might have multiple instances of the same addon and we will only check for duplication against the first encountered one. Previously, the name was all cared about, so it worked just fine.