### PR TITLE
Update `lazyLoading` option to accept a hash

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -64,7 +64,7 @@ function findHost() {
   // Keep iterating upward until we don't have a grandparent.
   // Has to do this grandparent check because at some point we hit the project.
   do {
-    if (current.lazyLoading === true) { return current; }
+    if (current.lazyLoading.enabled === true) { return current; }
     app = current.app || app;
   } while (current.parent.parent && (current = current.parent));
 
@@ -79,7 +79,7 @@ function findHostsHost() {
   // Keep iterating upward until we don't have a grandparent.
   // Has to do this grandparent check because at some point we hit the project.
   do {
-    if (current.lazyLoading === true) {
+    if (current.lazyLoading.enabled === true) {
       if (foundHost) {
         return current;
       }
@@ -287,9 +287,9 @@ module.exports = {
 
     options.cacheKeyForTree = function(treeType) {
       // We do different things in the addon, public, and engine trees based on
-      // the value of `lazyLoading`, so we add it to the cache key
+      // the value of `lazyLoading.enabled`, so we add it to the cache key
       if (treeType === 'addon' || treeType === 'public' || treeType === 'engine') {
-        return calculateCacheKeyForTree(treeType, this, [ this.lazyLoading ]);
+        return calculateCacheKeyForTree(treeType, this, [ this.lazyLoading.enabled ]);
       } else {
         return calculateCacheKeyForTree(treeType, this);
       }
@@ -320,7 +320,7 @@ module.exports = {
       while (queue.length) {
         var addon = queue.pop();
 
-        if (addon.lazyLoading) { continue; }
+        if (addon.lazyLoading && addon.lazyLoading.enabled) { continue; }
         if (addonNames.indexOf(addon.name) !== -1) { continue; }
 
         addonNames.push(addon.name);
@@ -372,6 +372,14 @@ module.exports = {
     options.init = function() {
       this.options = defaultsDeep(options, DEFAULT_CONFIG);
 
+      // Ensure lazyLoading is a hash, retain backwards compatibility with using
+      // a boolean value
+      if (typeof this.lazyLoading === "boolean") {
+        this.lazyLoading = {
+          enabled: this.lazyLoading
+        };
+      }
+
       // NOTE: This is a beautiful hack to deal with core object calling toString on the function.
       // It'll throw a deprecation warning if this isn't present because it doesn't see a `_super`
       // invocation. Do not remove the following line!
@@ -390,7 +398,7 @@ module.exports = {
 
       // Require that the user specify a lazyLoading property.
       if (!('lazyLoading' in this)) {
-        this.ui.writeDeprecateLine(this.pkg.name + ' engine must specify the `lazyLoading` property to `true` or `false` as to whether the engine should be lazily loaded.');
+        this.ui.writeDeprecateLine(this.pkg.name + ' engine must specify the `lazyLoading.enabled` property as to whether the engine should be lazily loaded.');
       }
 
       if (shouldCompactReexports(this)) {
@@ -433,7 +441,7 @@ module.exports = {
         target._mergeTrees = host._mergeTrees;
 
         // We're delegating to the upstream EmberApp behavior for eager engines.
-        if (this.lazyLoading !== true) {
+        if (this.lazyLoading.enabled !== true) {
           // This is hard-coded in Ember CLI, not tied to treePaths.
           asset.replace(/^vendor/, '');
         }
@@ -442,7 +450,7 @@ module.exports = {
 
       var originalIncluded = this.included;
       this.included = function() {
-        if (this.lazyLoading === true) {
+        if (this.lazyLoading.enabled === true) {
           // Do this greedily so that it runs before the `included` hook.
           this.import('engines-dist/' + this.name + '/assets/engine-vendor.js');
           this.import('engines-dist/' + this.name + '/assets/engine-vendor.css');
@@ -467,7 +475,7 @@ module.exports = {
               var stack = (new Error()).stack;
               ui.writeWarnLine('`app.import` should be avoided and `this.import` should be used instead. ' +
                                'Using `app.import` forces the asset in question to be hoisted in all scenarios (' +
-                               'regardless of `lazyLoading` flag).\n\n  Import performed on `' + name + '`\'s `app` argument at:\n\n  ' +
+                               'regardless of `lazyLoading.enabled` flag).\n\n  Import performed on `' + name + '`\'s `app` argument at:\n\n  ' +
                                stack + '\n'
                               );
               return originalHostImport.apply(this, arguments);
@@ -503,7 +511,7 @@ module.exports = {
       // Replace `treeForAddon` so that we control how this engine gets built.
       // We may or may not want it to be combined like a default addon.
       this.treeForAddon = function() {
-        if (this.lazyLoading === true) { return; }
+        if (this.lazyLoading.enabled === true) { return; }
 
         // NOT LAZY LOADING!
         // This is the scenario where we want to act like an addon.
@@ -530,7 +538,8 @@ module.exports = {
         // We only calculate our external tree for eager engines
         // if they're going to be consumed by a lazy engine.
         var externalTree;
-        if (this._findHost().lazyLoading === true) {
+        var hostLazyLoading = this._findHost().lazyLoading;
+        if (hostLazyLoading && hostLazyLoading.enabled === true) {
           externalTree = buildExternalTree.call(this);
         }
 
@@ -612,7 +621,7 @@ module.exports = {
       this.treeForPublic = function() {
         // NOT LAZY LOADING!
         // In this scenario we just want to do the default behavior and bail.
-        if (this.lazyLoading !== true) {
+        if (this.lazyLoading.enabled !== true) {
           return originalTreeForPublic.apply(this, arguments);
         }
 
@@ -854,8 +863,8 @@ module.exports = {
           // when using deprecated 0.4 style processing, we allow the styles tree to be
           // hoisted to the top level host
         (this.useDeprecatedIncorrectCSSProcessing !== true && name === 'styles') ||
-        (name === 'addon' && this.lazyLoading === true) ||
-        (name === 'public' && this.lazyLoading === true)
+        (name === 'addon' && this.lazyLoading.enabled === true) ||
+        (name === 'public' && this.lazyLoading.enabled === true)
       ) {
         trees = [];
       } else {

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -289,7 +289,7 @@ module.exports = {
       // We do different things in the addon, public, and engine trees based on
       // the value of `lazyLoading.enabled`, so we add it to the cache key
       if (treeType === 'addon' || treeType === 'public' || treeType === 'engine') {
-        return calculateCacheKeyForTree(treeType, this, [ this.lazyLoading.enabled ]);
+        return calculateCacheKeyForTree(treeType, this, [ this.lazyLoading ]);
       } else {
         return calculateCacheKeyForTree(treeType, this);
       }


### PR DESCRIPTION
Updates the `lazyLoading` option to accept a hash as its value. This is in preparation for a future PR to enable further options to be added to the lazy loading functionality.

Backwards compatibility has been retained by converting boolean values into a hash, e.g.

```js
lazyLoading: true

// Would be converted to

lazyLoading: {
  enabled: true
}
```

Not sure if this needs tests and if so, where they should actually be located as I had a quick look but couldn't find any existing tests for the flag.

cc/ @rwjblue 