### PR TITLE
Introduce `lazyLoading.includeRoutesInApplication` option

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -185,6 +185,29 @@ var buildEngineJSTreeWithoutRoutes = memoize(function buildEngineJSTreeWithoutRo
   });
 });
 
+var buildEngineRoutesJSTree = memoize(function buildEngineRoutesJSTree() {
+  // Get complete engine JS tree
+  var engineAppTree = buildEngineJSTree.call(this);
+  // Separate routes
+  var engineRoutesTree = new DependencyFunnel(engineAppTree, {
+    include: true,
+    entry: this.name+'/routes.js',
+    external: ['ember-engines/routes']
+  });
+  // If babel options aren't defined, we need to transpile the modules.
+  if (!this.options || !this.options.babel) {
+    engineRoutesTree = processBabel(engineRoutesTree);
+  }
+  // Concatenate routes.js and its dependencies into a single file.
+  engineRoutesTree = concat(engineRoutesTree, {
+    allowNone: true,
+    inputFiles: ['**/*.js'],
+    outputFile: 'engines-dist/' + this.name + '/assets/routes.js'
+  });
+  // Return concatenated JS tree
+  return engineRoutesTree;
+});
+
 var buildVendorJSWithImports = memoize(function buildVendorJSWithImports(concatTranspiledVendorJSTree) {
   var externalTree = buildExternalTree.call(this);
   var combined = mergeTrees([externalTree, concatTranspiledVendorJSTree].filter(Boolean), { overwrite: true });
@@ -487,10 +510,15 @@ module.exports = {
         this.nonDuplicatedAddonInvoke('included', [this]);
       };
 
+      // The treeForEngine method constructs and returns a tree that represents
+      // the engines routes.js file and its dependencies. This is used later to
+      // promote the engines routes.js to the host.
+      //
+      // If the lazyLoading.includeRoutesInApplication option is false, we don't
+      // want to promote the routes into the host.
       this.treeForEngine = function() {
-        // Unless includeRoutesInApplication is false, if this engine or any of
-        // its parents are lazy we need to promote its routes.
-        if (!this._hasLazyAncestor || this.lazyLoading.includeRoutesInApplication === false) { return; }
+        var extractRoutes = this._hasLazyAncestor && this.lazyLoading.includeRoutesInApplication === false;
+        if (extractRoutes) { return; }
 
         // The only thing that we want to promote from a lazy engine is the
         // routes.js file and all of its dependencies, which is why we build the
@@ -665,24 +693,10 @@ module.exports = {
 
         var engineJSTree = buildEngineJSTreeWithoutRoutes.call(this);
 
-        // If includeRoutesInApplication is false, separate the routes.js file
-        // and its dependencies
-        if (this.lazyLoading.includeRoutesInApplication === false) {
-          var engineAppTree = buildEngineJSTree.call(this);
-          var engineRoutesTree = new DependencyFunnel(engineAppTree, {
-            include: true,
-            entry: this.name+'/routes.js',
-            external: ['ember-engines/routes']
-          });
-        }
-
         // If babel options aren't defined, we need to transpile the modules.
         if (!this.options || !this.options.babel) {
           engineJSTree = processBabel(engineJSTree);
           vendorJSTree = processBabel(vendorJSTree);
-          if (this.lazyLoading.includeRoutesInApplication === false) {
-            engineRoutesTree = processBabel(engineRoutesTree);
-          }
         }
 
         // Concatenate all of the engine's JavaScript into a single file.
@@ -691,15 +705,6 @@ module.exports = {
           inputFiles: ['**/*.js'],
           outputFile: 'engines-dist/' + this.name + '/assets/engine.js'
         });
-
-        // Concatenate routes.js and its dependencies into a single file.
-        if (this.lazyLoading.includeRoutesInApplication === false) {
-          var concatEngineRoutesTree = concat(engineRoutesTree, {
-            allowNone: true,
-            inputFiles: ['**/*.js'],
-            outputFile: 'engines-dist/' + this.name + '/assets/routes.js'
-          });
-        }
 
         // Concatenate all of the engine's "vendor" trees
         var concatVendorJSTree = concat(vendorJSTree, {
@@ -728,9 +733,15 @@ module.exports = {
           vendorJSImportTree,
           concatEngineTree
         ];
-        if (this.lazyLoading.includeRoutesInApplication === false) {
-          finalMergeTrees.push(concatEngineRoutesTree);
+
+        // Separate engines routes from the host if includeRoutesInApplication
+        // is false
+        var separateRoutes = this.lazyLoading.includeRoutesInApplication === false;
+        if (separateRoutes) {
+          var engineRoutesTree = buildEngineRoutesJSTree.call(this);
+          finalMergeTrees.push(engineRoutesTree);
         }
+
         return mergeTrees(finalMergeTrees.filter(Boolean), {
           overwrite: true
         });

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -517,8 +517,8 @@ module.exports = {
       // If the lazyLoading.includeRoutesInApplication option is false, we don't
       // want to promote the routes into the host.
       this.treeForEngine = function() {
-        var extractRoutes = this._hasLazyAncestor && this.lazyLoading.includeRoutesInApplication === false;
-        if (extractRoutes) { return; }
+        var extractRoutes = this._hasLazyAncestor && this.lazyLoading.includeRoutesInApplication !== false;
+        if (!extractRoutes) { return; }
 
         // The only thing that we want to promote from a lazy engine is the
         // routes.js file and all of its dependencies, which is why we build the

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -205,7 +205,7 @@ var buildEngineRoutesJSTree = memoize(function buildEngineRoutesJSTree() {
     outputFile: 'engines-dist/' + this.name + '/assets/routes.js'
   });
   // Return concatenated JS tree
-  return engineRoutesTree;
+  return this.debugTree(engineRoutesTree, 'routes:output');
 });
 
 var buildVendorJSWithImports = memoize(function buildVendorJSWithImports(concatTranspiledVendorJSTree) {

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -488,8 +488,9 @@ module.exports = {
       };
 
       this.treeForEngine = function() {
-        // If this engine is lazy or any of its parents are lazy we need to promote its routes.
-        if (!this._hasLazyAncestor) { return; }
+        // Unless includeRoutesInApplication is false, if this engine or any of
+        // its parents are lazy we need to promote its routes.
+        if (!this._hasLazyAncestor || this.lazyLoading.includeRoutesInApplication === false) { return; }
 
         // The only thing that we want to promote from a lazy engine is the
         // routes.js file and all of its dependencies, which is why we build the
@@ -664,10 +665,24 @@ module.exports = {
 
         var engineJSTree = buildEngineJSTreeWithoutRoutes.call(this);
 
+        // If includeRoutesInApplication is false, separate the routes.js file
+        // and its dependencies
+        if (this.lazyLoading.includeRoutesInApplication === false) {
+          var engineAppTree = buildEngineJSTree.call(this);
+          var engineRoutesTree = new DependencyFunnel(engineAppTree, {
+            include: true,
+            entry: this.name+'/routes.js',
+            external: ['ember-engines/routes']
+          });
+        }
+
         // If babel options aren't defined, we need to transpile the modules.
         if (!this.options || !this.options.babel) {
           engineJSTree = processBabel(engineJSTree);
           vendorJSTree = processBabel(vendorJSTree);
+          if (this.lazyLoading.includeRoutesInApplication === false) {
+            engineRoutesTree = processBabel(engineRoutesTree);
+          }
         }
 
         // Concatenate all of the engine's JavaScript into a single file.
@@ -676,6 +691,15 @@ module.exports = {
           inputFiles: ['**/*.js'],
           outputFile: 'engines-dist/' + this.name + '/assets/engine.js'
         });
+
+        // Concatenate routes.js and its dependencies into a single file.
+        if (this.lazyLoading.includeRoutesInApplication === false) {
+          var concatEngineRoutesTree = concat(engineRoutesTree, {
+            allowNone: true,
+            inputFiles: ['**/*.js'],
+            outputFile: 'engines-dist/' + this.name + '/assets/routes.js'
+          });
+        }
 
         // Concatenate all of the engine's "vendor" trees
         var concatVendorJSTree = concat(vendorJSTree, {
@@ -696,17 +720,20 @@ module.exports = {
         }
 
         // Merge all of our final trees!
-        return mergeTrees(
-          [
-            publicRelocated,
-            addonsEnginesPublicTreesMerged,
-            otherAssets,
-            finalStylesTree,
-            vendorJSImportTree,
-            concatEngineTree
-          ].filter(Boolean),
-          { overwrite: true }
-        );
+        var finalMergeTrees = [
+          publicRelocated,
+          addonsEnginesPublicTreesMerged,
+          otherAssets,
+          finalStylesTree,
+          vendorJSImportTree,
+          concatEngineTree
+        ];
+        if (this.lazyLoading.includeRoutesInApplication === false) {
+          finalMergeTrees.push(concatEngineRoutesTree);
+        }
+        return mergeTrees(finalMergeTrees.filter(Boolean), {
+          overwrite: true
+        });
       };
 
       return result;

--- a/node-tests/acceptance/build-test.js
+++ b/node-tests/acceptance/build-test.js
@@ -346,6 +346,30 @@ describe('Acceptance', function() {
       });
     }));
 
+    it('correctly separates routes.js and its imports when lazyLoading.includeRoutesInApplication is false', co.wrap(function* () {
+      let app = new AddonTestApp();
+      let engineName = 'separate-routes';
+
+      yield app.create('engine-testing', { noFixtures: true });
+      let engine = yield InRepoEngine.generate(app, engineName, { lazy: true });
+
+      engine.writeFixture(require(`../fixtures/${engineName}/data`));
+
+      let output = yield build(app);
+
+      let hoistedModules = [
+        'routes',
+        'absolute-routes-import',
+        'relative-routes-import'
+      ];
+
+      hoistedModules.forEach((module) => {
+        let matcher = moduleMatcher(`${engineName}/${module}`);
+        output.doesNotContain(`assets/vendor.js`, matcher);
+        output.contains(`engines-dist/${engineName}/assets/routes.js`, matcher);
+      });
+    }));
+
     it('does not duplicate addons in lazy engines that appear in the host', co.wrap(function* () {
       let app = new AddonTestApp();
       let appName = 'engine-testing';

--- a/node-tests/fixtures/separate-routes/data.js
+++ b/node-tests/fixtures/separate-routes/data.js
@@ -1,0 +1,30 @@
+const stripIndent = require('common-tags').stripIndent;
+
+module.exports = {
+  addon: {
+    'absolute-routes-import.js': `export default {};`,
+    'relative-routes-import.js': `export default {};`,
+    'routes.js': stripIndent`
+      import buildRoutes from 'ember-engines/routes';
+      import 'separate-routes/absolute-routes-import';
+      import './relative-routes-import';
+
+      export default buildRoutes(function() {
+      });
+    `,
+  },
+  'index.js': stripIndent`
+    var EngineAddon = require('ember-engines/lib/engine-addon');
+    module.exports = EngineAddon.extend({
+      name: 'separate-routes',
+      lazyLoading: {
+        enabled: true,
+        includeRoutesInApplication: false
+      },
+
+      isDevelopingAddon: function() {
+        return true;
+      }
+    });
+  `
+};


### PR DESCRIPTION
Introduces a new `lazyLoading.includeRoutesInApplication` option which enables lazy engines to output their `routes.js` file to a stand-alone file rather than bundling it into the hosts `vendor.js` file.

This will enable engines to be discovered dynamically at runtime rather than requiring engines to be declared statically at build time.

Still needs some tests which I will do once others have reviewed.

**Usage:**

```js
// Prevent routes being bundled into hosts vendor.js
lazyLoading: {
  enabled: true,
  includeRoutesInApplication: false
}
```

**TODO:**
- [x] Tests

cc/ @rwjblue @trentmwillis