### PR TITLE
Use new `lazyLoading` format in `in-repo-engine` blueprint

### DIFF
--- a/blueprints/in-repo-engine/index.js
+++ b/blueprints/in-repo-engine/index.js
@@ -15,7 +15,6 @@ module.exports = Object.assign({}, InRepoAddon, {
     return {
       name: name,
       modulePrefix: name,
-      hasLazyFlag: typeof options.lazy !== 'undefined',
       isLazy: !!options.lazy
     };
   },

--- a/blueprints/in-repo-engine/routable-files/lib/__name__/index.js
+++ b/blueprints/in-repo-engine/routable-files/lib/__name__/index.js
@@ -4,9 +4,11 @@
 const EngineAddon = require('ember-engines/lib/engine-addon');
 
 module.exports = EngineAddon.extend({
-  name: '<%= dasherizedModuleName %>',<% if (hasLazyFlag) { %>
+  name: '<%= dasherizedModuleName %>',
 
-  lazyLoading: <%= isLazy %>,<% } %>
+  lazyLoading: {
+    enabled: <%= isLazy %>
+  },
 
   isDevelopingAddon() {
     return true;

--- a/blueprints/in-repo-engine/routeless-files/lib/__name__/index.js
+++ b/blueprints/in-repo-engine/routeless-files/lib/__name__/index.js
@@ -4,9 +4,11 @@
 const EngineAddon = require('ember-engines/lib/engine-addon');
 
 module.exports = EngineAddon.extend({
-  name: '<%= dasherizedModuleName %>',<% if (hasLazyFlag) { %>
+  name: '<%= dasherizedModuleName %>',
 
-  lazyLoading: <%= isLazy %>,<% } %>
+  lazyLoading: {
+    enabled: <%= isLazy %>
+  },
 
   isDevelopingAddon() {
     return true;


### PR DESCRIPTION
This PR updates the `in-repo-engine` blueprint to use the new `lazyLoading` option format.

This change will also ensure that the `lazyLoading` option is **always** set (defaulting to false), as currently, generated engines produce the following deprecation warning.

```
DEPRECATION: {ENGINE_NAME} engine must specify the `lazyLoading.enabled` property as to whether the engine should be lazily loaded.
```