### PR TITLE
Assert if link-to is used within a routeless engine

### DIFF
--- a/addon/components/link-to-component.js
+++ b/addon/components/link-to-component.js
@@ -17,7 +17,7 @@ export default LinkComponent.extend({
     let owner = getOwner(this);
 
     assert(
-      `You attempted to use a link-to within a routeless engine, this is not supported.`,
+      `You attempted to use {{link-to}} within a routeless engine, this is not supported. Use {{link-to-external}} to construct links within a routeless engine. See http://ember-engines.com/guide/linking-and-external-links for more info.`,
       owner.mountPoint !== undefined
     );
 

--- a/addon/components/link-to-component.js
+++ b/addon/components/link-to-component.js
@@ -6,7 +6,8 @@ const {
   getOwner,
   get,
   set,
-  typeOf
+  typeOf,
+  assert
 } = Ember;
 
 export default LinkComponent.extend({
@@ -14,6 +15,11 @@ export default LinkComponent.extend({
     this._super(...arguments);
 
     let owner = getOwner(this);
+
+    assert(
+      `You attempted to use a link-to within a routeless engine, this is not supported.`,
+      owner.mountPoint !== undefined
+    );
 
     if (owner.mountPoint) {
       // Prepend engine mount point to targetRouteName


### PR DESCRIPTION
Adds an assertion if `{{link-to}}` is used within a routeless engine due to it not being supported.

Not sure if we still want to scope `{{link-to}}`'s within a routeless engine, or if the assertion alone is enough.

Closes #272