### PR TITLE
use require.has instead of try/catch

### DIFF
--- a/addon-test-support/engine-resolver-for.js
+++ b/addon-test-support/engine-resolver-for.js
@@ -21,9 +21,10 @@ import EmberResolver from 'ember-resolver';
  */
 export default function engineResolverFor(engineName, modulePrefix = engineName) {
   let Resolver;
-  try {
+
+  if (require.has(`${engineName}/resolver`)) {
     Resolver = require(`${engineName}/resolver`).default;
-  } catch (e) {
+  } else {
     Resolver = EmberResolver;
   }
   return Resolver.create({ namespace: { modulePrefix } });


### PR DESCRIPTION
* extra error throws is wasteful
* legit failures in the resolver module are now no longer hidden.