### PR TITLE
compiledEngineCSSTree should not be falsy

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -564,7 +564,10 @@ module.exports = {
           engineCSSTree = this._treeFor('addon-styles');
         }
 
-        var compiledEngineCSSTree = this.debugTree(this.compileStyles(engineCSSTree), 'styles');
+        var compiledEngineCSSTree = this.compileStyles(engineCSSTree);
+        if(compiledEngineCSSTree) {
+          compiledEngineCSSTree = this.debugTree(compiledEngineCSSTree, 'styles');
+        }
 
         // If any of this engine's ancestors are lazy we need to
         // remove the engine's routes file, because we've already accounted


### PR DESCRIPTION
`this.compiledStyles` can return a falsy value as such `this.debugTree` should not be called in this instance.