### PR TITLE
[BUGFIX release]: ancestorHostAddons return value

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -332,7 +332,7 @@ module.exports = {
       var host = findHostsHost.call(this);
 
       if (!host) {
-        return [];
+        return {};
       }
 
       var hostIsEngine = !!host.ancestorHostAddons;


### PR DESCRIPTION
Without this, you cannot build engines with who's names are built-in array methods such as "filter".
The return type of the function is an `Object` not an `Array`