### PR TITLE
Extract private `_concatStyles` hook to allow customized concat strategies.

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -397,6 +397,18 @@ module.exports = {
 
     options.debugTree = BroccoliDebug.buildDebugCallback('ember-engines:' + options.name);
 
+    options._concatStyles = options._concatStyles || function concatProcessedStyles(type, tree) {
+      var engineStylesOutputDir = 'engines-dist/' + this.name + '/assets/';
+
+      // Move styles tree into the correct place.
+      // `**/*.css` all gets merged.
+      return concat(tree, {
+        allowNone: true,
+        inputFiles: ['**/*.css'],
+        outputFile: engineStylesOutputDir + type + '.css'
+      });
+    };
+
     options.init = function() {
       this.options = defaultsDeep(options, DEFAULT_CONFIG);
 
@@ -615,22 +627,12 @@ module.exports = {
 
           processedEngineStylesTree = this.debugTree(processedEngineStylesTree, 'engine-style:postprocessed');
 
-          // Move styles tree into the correct place.
-          // `**/*.css` all gets merged.
-          primaryStyleTree = concat(processedEngineStylesTree, {
-            allowNone: true,
-            inputFiles: ['**/*.css'],
-            outputFile: engineStylesOutputDir + 'engine.css'
-          });
+          primaryStyleTree = this._concatStyles('engine', processedEngineStylesTree);
 
           primaryStyleTree = this.debugTree(primaryStyleTree, 'engine-style:output');
         }
 
-        var concatVendorCSSTree = concat(vendorCSSTree, {
-          allowNone: true,
-          inputFiles: ['**/*.css'],
-          outputFile: engineStylesOutputDir + 'engine-vendor.css'
-        });
+        var concatVendorCSSTree = this._concatStyles('engine-vendor', vendorCSSTree);
 
         concatVendorCSSTree = this.debugTree(concatVendorCSSTree, 'vendor-style:pre-import');
 


### PR DESCRIPTION
This is private for now, because I suspect that we should actually deprecate this "auto concat all the things" behavior completely (in favor of the preprocessor in use emitting the correct file).