### PR TITLE
Update to latest ember-asset-loader version.

### DIFF
--- a/node-tests/acceptance/build-test.js
+++ b/node-tests/acceptance/build-test.js
@@ -16,7 +16,7 @@ const cssCommentMatcher = matchers.cssComment;
 
 describe('Acceptance', function() {
   describe('build', function() {
-    this.timeout(300000);
+    this.timeout(450000);
 
     const DEFAULT_ROUTABLE_ENGINE_MODULES = [
       'engine',

--- a/node-tests/acceptance/build-test.js
+++ b/node-tests/acceptance/build-test.js
@@ -108,7 +108,7 @@ describe('Acceptance', function() {
       let output = yield build(app);
 
       // Verify we have the manifest and the lazy engine assets
-      expect(output.manifest()).to.deep.equal(expectedManifests['lazy']);
+      expect(output.manifest()).to.deep.equal(expectedManifests['eager-in-lazy']);
       output.contains('assets/node-asset-manifest.js');
       output.contains(`engines-dist/${engineName}/assets/engine-vendor.css`, cssCommentMatcher(`${nestedEngineName}.css`));
       output.contains(`engines-dist/${engineName}/assets/engine-vendor.js`);

--- a/node-tests/fixtures/expected-manifests.json
+++ b/node-tests/fixtures/expected-manifests.json
@@ -8,6 +8,27 @@
       "lazy": {
         "assets": [
           {
+            "uri": "/engines-dist/lazy/assets/engine-vendor.js",
+            "type": "js"
+          },
+          {
+            "uri": "/engines-dist/lazy/assets/engine.css",
+            "type": "css"
+          },
+          {
+            "uri": "/engines-dist/lazy/assets/engine.js",
+            "type": "js"
+          }
+        ]
+      }
+    }
+  },
+
+  "eager-in-lazy": {
+    "bundles": {
+      "lazy": {
+        "assets": [
+          {
             "uri": "/engines-dist/lazy/assets/engine-vendor.css",
             "type": "css"
           },
@@ -33,10 +54,6 @@
       "lazy-in-eager": {
         "assets": [
           {
-            "uri": "/engines-dist/lazy-in-eager/assets/engine-vendor.css",
-            "type": "css"
-          },
-          {
             "uri": "/engines-dist/lazy-in-eager/assets/engine-vendor.js",
             "type": "js"
           },
@@ -58,10 +75,6 @@
       "lazy-in-lazy": {
         "assets": [
           {
-            "uri": "/engines-dist/lazy-in-lazy/assets/engine-vendor.css",
-            "type": "css"
-          },
-          {
             "uri": "/engines-dist/lazy-in-lazy/assets/engine-vendor.js",
             "type": "js"
           },
@@ -77,10 +90,6 @@
       },
       "lazy": {
         "assets": [
-          {
-            "uri": "/engines-dist/lazy/assets/engine-vendor.css",
-            "type": "css"
-          },
           {
             "uri": "/engines-dist/lazy/assets/engine-vendor.js",
             "type": "js"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "broccoli-merge-trees": "^1.0.0",
     "broccoli-test-helper": "^1.1.0",
     "calculate-cache-key-for-tree": "^1.0.0",
-    "ember-asset-loader": "^0.2.0",
+    "ember-asset-loader": "^0.3.0",
     "ember-cli-babel": "^6.7.1",
     "ember-cli-preprocess-registry": "^3.0.0",
     "ember-cli-string-utils": "^1.0.0",

--- a/tests/acceptance/lazy-routeable-engine-test.js
+++ b/tests/acceptance/lazy-routeable-engine-test.js
@@ -48,11 +48,10 @@ moduleForAcceptance('Acceptance | lazy routable engine', {
 });
 
 function verifyInitialBlogRoute(assert, loadEvents, application) {
-  assert.equal(loadEvents.length, 4, 'loaded 4 assets');
-  assert.deepEqual(loadEvents[0].split(SEPARATORS), [ '', 'engines-dist', 'ember-blog', 'assets', 'engine-vendor.css' ], 'loaded engine vendor css');
-  assert.deepEqual(loadEvents[1].split(SEPARATORS), [ '', 'engines-dist', 'ember-blog', 'assets', 'engine-vendor.js' ], 'loaded engine vendor js');
-  assert.deepEqual(loadEvents[2].split(SEPARATORS), [ '', 'engines-dist', 'ember-blog', 'assets', 'engine.css' ], 'loaded engine css');
-  assert.deepEqual(loadEvents[3].split(SEPARATORS), [ '', 'engines-dist', 'ember-blog', 'assets', 'engine.js' ], 'loaded engine js');
+  assert.equal(loadEvents.length, 3, 'loaded 3 assets');
+  assert.deepEqual(loadEvents[0].split(SEPARATORS), [ '', 'engines-dist', 'ember-blog', 'assets', 'engine-vendor.js' ], 'loaded engine vendor js');
+  assert.deepEqual(loadEvents[1].split(SEPARATORS), [ '', 'engines-dist', 'ember-blog', 'assets', 'engine.css' ], 'loaded engine css');
+  assert.deepEqual(loadEvents[2].split(SEPARATORS), [ '', 'engines-dist', 'ember-blog', 'assets', 'engine.js' ], 'loaded engine js');
 
   assert.equal(currentURL(), '/routable-engine-demo/blog/new');
 
@@ -61,14 +60,14 @@ function verifyInitialBlogRoute(assert, loadEvents, application) {
 }
 
 test('it should pause to load JS and CSS assets on deep link into a lazy Engine', function(assert) {
-  assert.expect(8);
+  assert.expect(7);
 
   visit('/routable-engine-demo/blog/new');
   andThen(() => verifyInitialBlogRoute(assert, this.loadEvents, this.application));
 });
 
 test('it should pause to load JS and CSS assets on an initial transition into a lazy Engine', function(assert) {
-  assert.expect(8);
+  assert.expect(7);
 
   visit('/routable-engine-demo');
   click('.blog-new:last');
@@ -76,7 +75,7 @@ test('it should pause to load JS and CSS assets on an initial transition into a 
 });
 
 test('it should not pause to load assets on subsequent transitions into a lazy Engine', function(assert) {
-  assert.expect(11);
+  assert.expect(10);
 
   visit('/routable-engine-demo/blog/new');
   andThen(() => verifyInitialBlogRoute(assert, this.loadEvents, this.application));
@@ -88,13 +87,13 @@ test('it should not pause to load assets on subsequent transitions into a lazy E
 
   click('.blog-new');
   andThen(() => {
-    assert.equal(this.loadEvents.length, 4, 'did not load additional assets');
+    assert.equal(this.loadEvents.length, 3, 'did not load additional assets');
     assert.equal(currentURL(), '/routable-engine-demo/blog/new');
   });
 });
 
 test('it should not pause to load assets on transition to a loaded, but not initialized instance of a lazy Engine (e.g., Engine mounted more than once)', function(assert) {
-  assert.expect(11);
+  assert.expect(10);
 
   visit('/routable-engine-demo/blog/new');
   andThen(() => verifyInitialBlogRoute(assert, this.loadEvents, this.application));
@@ -106,7 +105,7 @@ test('it should not pause to load assets on transition to a loaded, but not init
 
   click('.ember-blog-new:last');
   andThen(() => {
-    assert.equal(this.loadEvents.length, 4, 'did not load additional assets');
+    assert.equal(this.loadEvents.length, 3, 'did not load additional assets');
     assert.equal(currentURL(), '/routable-engine-demo/ember-blog/new');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1307,7 +1307,7 @@ broccoli-lint-eslint@^3.3.0:
     lodash.defaultsdeep "^4.6.0"
     md5-hex "^2.0.0"
 
-broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.1, broccoli-merge-trees@^1.1.2:
+broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz#a001519bb5067f06589d91afa2942445a2d0fdb5"
   dependencies:
@@ -2106,18 +2106,18 @@ ember-ajax@^3.0.0:
   dependencies:
     ember-cli-babel "^6.0.0"
 
-ember-asset-loader@^0.2.0:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/ember-asset-loader/-/ember-asset-loader-0.2.7.tgz#a1af2ad8b69a040317ec2b6d58c5647ed475347e"
+ember-asset-loader@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/ember-asset-loader/-/ember-asset-loader-0.3.0.tgz#8a229422d830bba9949ff67b9cdfad5ea2cbfa75"
   dependencies:
     broccoli-caching-writer "^3.0.3"
     broccoli-funnel "^1.0.8"
-    broccoli-merge-trees "^1.1.2"
-    ember-cli-babel "^5.1.6"
-    exists-sync "0.0.3"
-    fs-extra "^0.30.0"
+    broccoli-merge-trees "^2.0.0"
+    ember-cli-babel "^6.7.2"
+    exists-sync "^0.0.4"
+    fs-extra "^4.0.1"
     object-assign "^4.1.0"
-    walk-sync "^0.2.7"
+    walk-sync "^0.3.2"
 
 "ember-blog@file:./tests/dummy/lib/ember-blog":
   version "0.0.0"
@@ -2176,7 +2176,7 @@ ember-cli-babel@*, ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.7, ember-
     clone "^2.0.0"
     ember-cli-version-checker "^2.0.0"
 
-ember-cli-babel@^5.1.5, ember-cli-babel@^5.1.6, ember-cli-babel@^5.2.1:
+ember-cli-babel@^5.1.5, ember-cli-babel@^5.2.1:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz#5ce4f46b08ed6f6d21e878619fb689719d6e8e13"
   dependencies:
@@ -2185,6 +2185,23 @@ ember-cli-babel@^5.1.5, ember-cli-babel@^5.1.6, ember-cli-babel@^5.2.1:
     clone "^2.0.0"
     ember-cli-version-checker "^1.0.2"
     resolve "^1.1.2"
+
+ember-cli-babel@^6.7.2:
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.7.2.tgz#9c0886194266f17a98fe5c536d170878ac287009"
+  dependencies:
+    amd-name-resolver "0.0.7"
+    babel-plugin-debug-macros "^0.1.11"
+    babel-plugin-ember-modules-api-polyfill "^1.4.1"
+    babel-plugin-transform-es2015-modules-amd "^6.24.0"
+    babel-polyfill "^6.16.0"
+    babel-preset-env "^1.5.1"
+    broccoli-babel-transpiler "^6.1.2"
+    broccoli-debug "^0.6.2"
+    broccoli-funnel "^1.0.0"
+    broccoli-source "^1.1.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^2.0.0"
 
 ember-cli-broccoli-sane-watcher@^2.0.4:
   version "2.0.4"
@@ -3187,6 +3204,14 @@ fs-extra@^2.0.0:
 fs-extra@^3.0.0, fs-extra@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-3.0.1.tgz#3794f378c58b342ea7dbbb23095109c4b3b62291"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^3.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.1.tgz#7fc0c6c8957f983f57f306a24e5b9ddd8d0dd880"
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^3.0.0"
@@ -5860,7 +5885,7 @@ walk-sync@^0.2.5, walk-sync@^0.2.7:
     ensure-posix-path "^1.0.0"
     matcher-collection "^1.0.0"
 
-walk-sync@^0.3.0, walk-sync@^0.3.1:
+walk-sync@^0.3.0, walk-sync@^0.3.1, walk-sync@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.3.2.tgz#4827280afc42d0e035367c4a4e31eeac0d136f75"
   dependencies:


### PR DESCRIPTION
Primary changes included from 0.2.7 to 0.3.0:

* Update to latest dependencies (including ember-cli-babel@6).
* Drop support for Node < 4.
* Exclude empty files from the `asset-manifest.json`.

None of these changes are breaking for ember-engines@0.5.x users (we already dropped support for older Node and updated to ember-cli-babel@6), so this does not need to be a breaking change release for ember-engines.

TODO:

- [x] Update to pass tests now that a number of `engine-vendor.{js,css}` files are not present (causing request counts to be 1 less than expected)