### PR TITLE
Retry engine on assets error

### DIFF
--- a/addon/-private/router-ext.js
+++ b/addon/-private/router-ext.js
@@ -215,7 +215,7 @@ Router.reopen({
       enginePromise = this._assetLoader.loadBundle(name).then(
         () => this._registerEngine(name),
         (error) => {
-          delete enginePromises[name][instanceId];
+          enginePromises[name][instanceId] = undefined;
           throw error;
         }
       );

--- a/addon/-private/router-ext.js
+++ b/addon/-private/router-ext.js
@@ -216,7 +216,7 @@ Router.reopen({
         () => this._registerEngine(name),
         (error) => {
           delete enginePromises[name][instanceId];
-          return RSVP.reject(error);
+          throw error;
         }
       );
     }

--- a/addon/-private/router-ext.js
+++ b/addon/-private/router-ext.js
@@ -212,7 +212,13 @@ Router.reopen({
       enginePromise = RSVP.resolve();
     } else {
       // The Engine is not loaded and has no Promise
-      enginePromise = this._assetLoader.loadBundle(name).then(() => this._registerEngine(name));
+      enginePromise = this._assetLoader.loadBundle(name).then(
+        () => this._registerEngine(name),
+        (error) => {
+          delete enginePromises[name][instanceId];
+          return RSVP.reject(error);
+        }
+      );
     }
 
     return enginePromises[name][instanceId] = enginePromise.then(() => {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "broccoli-merge-trees": "^1.0.0",
     "broccoli-test-helper": "^1.1.0",
     "calculate-cache-key-for-tree": "^1.0.0",
-    "ember-asset-loader": "git+https://github.com/BBVAEngineering/ember-asset-loader.git#prevent-caching-errors",
+    "ember-asset-loader": "^0.3.1",
     "ember-cli-babel": "^6.7.1",
     "ember-cli-preprocess-registry": "^3.0.0",
     "ember-cli-string-utils": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "broccoli-merge-trees": "^1.0.0",
     "broccoli-test-helper": "^1.1.0",
     "calculate-cache-key-for-tree": "^1.0.0",
-    "ember-asset-loader": "^0.3.0",
+    "ember-asset-loader": "git+https://github.com/BBVAEngineering/ember-asset-loader.git#prevent-caching-errors",
     "ember-cli-babel": "^6.7.1",
     "ember-cli-preprocess-registry": "^3.0.0",
     "ember-cli-string-utils": "^1.0.0",


### PR DESCRIPTION
This pull tries to fix #471.

There are some changes in the acceptance tests that I don't like but I didn't find any other way to implement them.
I had to remove the exception adapter (`Ember.Test.adapter.exception`) because the router creates a new promise without an error handler ([L47:router.js](https://github.com/tildeio/router.js/blob/816c11f99bb169300ec98dbdb613bc2c0cf6c175/lib/router/handler-info.js#L47)). When I force an error in a transition, the exception is caught by the `ember-test` adapter making the test fail.
¿Do you know prevent the test failing?

Also I changed the `package.json` to trigger the build in Travis with the changes that I've done in [ember-asset-loader](https://github.com/ember-engines/ember-asset-loader/pull/57). This change should be removed.