### PR TITLE
Fix CI

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,6 +1,7 @@
 'use strict';
 
 module.exports = {
+  useYarn: true,
   scenarios: [
     {
       name: 'ember-lts-2.12',

--- a/node-tests/lint-test.js
+++ b/node-tests/lint-test.js
@@ -11,6 +11,7 @@ lint([
   'config',
   'lib',
   'node-tests',
-  'tests',
+  'tests/**/*.js',
+  '!tests/**/node_modules/**/*.js',
   'vendor',
 ]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2106,9 +2106,9 @@ ember-ajax@^3.0.0:
   dependencies:
     ember-cli-babel "^6.0.0"
 
-ember-asset-loader@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/ember-asset-loader/-/ember-asset-loader-0.3.0.tgz#8a229422d830bba9949ff67b9cdfad5ea2cbfa75"
+ember-asset-loader@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/ember-asset-loader/-/ember-asset-loader-0.3.1.tgz#5fc0bbd3ac458da4997dc6454df4c91d75c09b5a"
   dependencies:
     broccoli-caching-writer "^3.0.3"
     broccoli-funnel "^1.0.8"


### PR DESCRIPTION
Hopefully this fixes the issues with CI. As far as I can tell, Yarn is no longer running the `prepublish` script on install which is responsible for linking the test engines to their proper locations.