### PR TITLE
#404 exclude files from js bundle

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -35,6 +35,7 @@ var DEFAULT_CONFIG = {
     addon: 'addon',
   },
   minifyCSS: {},
+  jsFunnel: { exclude: {} },
 };
 
 var DEFAULT_BABEL_CONFIG = {
@@ -178,6 +179,16 @@ var buildEngineJSTree = memoize(function buildEngineJSTree() {
     engineSourceTree = this.treeGenerator(treePath);
   } else {
     engineSourceTree = addonTree;
+  }
+
+  // Filter funnel
+  var environment = process.env.EMBER_ENV;
+  var excludeFromJsFunnel = this.options.jsFunnel.exclude[environment];
+
+  if (excludeFromJsFunnel) {
+    engineSourceTree = new Funnel(engineSourceTree, {
+      exclude: excludeFromJsFunnel,
+    });
   }
 
   // We want the config and child app trees to be compiled with the engine source

--- a/node-tests/acceptance/build-test.js
+++ b/node-tests/acceptance/build-test.js
@@ -3,6 +3,7 @@
 const co = require('co');
 const expect = require('chai').expect;
 const AddonTestApp = require('ember-cli-addon-tests').AddonTestApp;
+const stripIndent = require('common-tags').stripIndent;
 
 const build = require('../helpers/build');
 const InRepoAddon = require('../helpers/in-repo-addon');
@@ -770,6 +771,79 @@ describe('Acceptance', function() {
         output.doesNotContain(
           `engines-dist/${engineName}/assets/engine-vendor.css`,
           cssCommentMatcher(`${addonName}.css`)
+        );
+      })
+    );
+
+    it(
+      'excludes files from js engine bundle',
+      co.wrap(function*() {
+        const app = new AddonTestApp();
+        const appName = 'engine-testing';
+        const engineName = 'lazy';
+
+        yield app.create(appName, { noFixtures: true });
+        const engine = yield InRepoEngine.generate(app, engineName, {
+          lazy: true,
+        });
+
+        engine.writeFixture({
+          'index.js': stripIndent`
+            var EngineAddon = require('ember-engines/lib/engine-addon');
+            module.exports = EngineAddon.extend({
+              name: '${engineName}',
+              lazyLoading: true,
+              jsFunnel: {
+                exclude: {
+                  development: [
+                    '${engineName}/routes/examples/*',
+                    /(debug|fixture)/,
+                  ],
+                },
+              },
+            });
+          `,
+          addon: {
+            components: {
+              'debug.js': '// my example component',
+            },
+            templates: {
+              components: {
+                'debug.hbs': '<h1>debug component</h1>',
+              },
+            },
+            routes: {
+              examples: {
+                'one.js': `export default {}`,
+                'two.js': `export default {}`,
+              },
+              'bar.js': `export default {}`,
+            },
+          },
+        });
+
+        const output = yield build(app, 'development');
+        const engineJsFile = `engines-dist/${engineName}/assets/engine.js`;
+
+        output.contains(
+          engineJsFile,
+          moduleMatcher(`${engineName}/routes/bar`)
+        );
+        output.doesNotContain(
+          engineJsFile,
+          moduleMatcher(`${engineName}/components/debug`)
+        );
+        output.doesNotContain(
+          engineJsFile,
+          moduleMatcher(`${engineName}/templates/components/debug`)
+        );
+        output.doesNotContain(
+          engineJsFile,
+          moduleMatcher(`${engineName}/routes/examples/one`)
+        );
+        output.doesNotContain(
+          engineJsFile,
+          moduleMatcher(`${engineName}/routes/examples/two`)
         );
       })
     );


### PR DESCRIPTION
Add jsBundle config to specify files that should be excluded from the bundle.
Configurable by environment:

Example:
```
var EngineAddon = require('ember-engines/lib/engine-addon');
var debugFiles = /(debug|fixture|\-test)/;
var prodExclude = [debugFiles, 'my-super-addon/routes/examples/*'];

module.exports = EngineAddon.extend({
	name: 'my-super-addon',
	lazyLoading: true,
	isDevelopingAddon: function() {
		return true;
	},
	jsFunnel: {
		exclude: {
			production: prodExclude,
			development: debugFiles
		}
	}
});

```