### PR TITLE
fix: ensure the "environment" is passed to the engine's config generator

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -976,14 +976,16 @@ module.exports = {
 
       @public
       @method engineConfig
-      @param {String} env Name of current environment (e.g. "developement")
-      @param {Object} baseConfig Initial engine configuration
       @return {Object} Configuration object that will be provided to the engine.
     */
-    options.engineConfig = function(env, baseConfig) {
+    options.engineConfig = function() {
       if (this._engineConfig) {
         return this._engineConfig;
       }
+
+      var host = findHost.call(this);
+      var env = host.env;
+      var baseConfig = {};
 
       var configPath = 'config';
 
@@ -1039,11 +1041,10 @@ module.exports = {
       @public
       @method contentFor
       @param type
-      @param config
     */
-    options.contentFor = function(type, config) {
+    options.contentFor = function(type) {
       if (type === 'head') {
-        var engineConfig = this.engineConfig(config.environment, {});
+        var engineConfig = this.engineConfig();
 
         var content =
           '<meta name="' +

--- a/node-tests/acceptance/build-test.js
+++ b/node-tests/acceptance/build-test.js
@@ -72,7 +72,11 @@ describe('Acceptance', function() {
         // Verify we have the manifest and the lazy engine assets
         expect(output.manifest()).to.deep.equal(expectedManifests['lazy']);
         output.contains('assets/node-asset-manifest.js');
-        output.contains(`engines-dist/${engineName}/config/environment.js`);
+        // Engine inherites its environment from the parent
+        output.contains(
+          `engines-dist/${engineName}/config/environment.js`,
+          /"environment":"development"/
+        );
         output.contains(`engines-dist/${engineName}/assets/engine-vendor.css`);
         output.contains(`engines-dist/${engineName}/assets/engine-vendor.js`);
         output.contains(`engines-dist/${engineName}/assets/engine-vendor.map`);


### PR DESCRIPTION
cc @trentmwillis 

The latest version of ember-engines is breaking an expectation in our apps that the "environment" key will always be set in `{{modulePrefix}}/config/environment`.

This change always grabs the `env` from the host application instead of assuming that it will be passed in from hooks like `contentFor`. @trentmwillis memoized the `engineConfig` method in the fastboot updates, and passing arguments to a memoized method can be problematic.