### PR TITLE
Fix issues with module paths changing in Ember 3.2.

### DIFF
--- a/addon/-private/engine-ext.js
+++ b/addon/-private/engine-ext.js
@@ -1,9 +1,7 @@
 import Application from '@ember/application';
 import EngineScopedLinkComponent from '../components/link-to-component';
 import ExternalLinkComponent from '../components/link-to-external-component';
-import emberRequire from './ext-require';
-
-const Engine = emberRequire('ember-application/system/engine');
+import Engine from '@ember/engine';
 
 Engine.reopen({
   buildRegistry() {

--- a/addon/-private/engine-instance-ext.js
+++ b/addon/-private/engine-instance-ext.js
@@ -1,8 +1,6 @@
 import { camelize } from '@ember/string';
 import { assert } from '@ember/debug';
-import emberRequire from './ext-require';
-
-const EngineInstance = emberRequire('ember-application/system/engine-instance');
+import EngineInstance from '@ember/engine/instance';
 
 EngineInstance.reopen({
   /**

--- a/addon/-private/ext-require.js
+++ b/addon/-private/ext-require.js
@@ -1,7 +1,0 @@
-import Ember from 'ember';
-
-export default function(moduleName, exportName = 'default') {
-  let module = Ember.__loader.require(moduleName);
-
-  return module[exportName];
-}

--- a/addon/-private/router-ext.js
+++ b/addon/-private/router-ext.js
@@ -4,12 +4,11 @@ import { assert } from '@ember/debug';
 import { get } from '@ember/object';
 import { getOwner } from '@ember/application';
 import Ember from 'ember';
-import emberRequire from './ext-require';
+import Route from '@ember/routing/route';
 
-const hasDefaultSerialize = emberRequire(
-  'ember-routing/system/route',
-  'hasDefaultSerialize'
-);
+function hasDefaultSerialize(handler) {
+  handler.serialize === Route.prototype.serialize;
+}
 
 const {
   Logger: { info }

--- a/addon/engine-instance.js
+++ b/addon/engine-instance.js
@@ -1,7 +1,3 @@
-import emberRequire from './-private/ext-require';
+import EngineInstance from '@ember/engines/instance';
 
-// Because feature flags are only valid for Ember canary builds,
-// `Ember.EngineInstance` won't be exposed publicly for beta builds. This export
-// provides a means to use this module with any ember build which privately
-// includes the `engine-instance` module.
-export default emberRequire('ember-application/system/engine-instance');
+export default EngineInstance;

--- a/addon/engine.js
+++ b/addon/engine.js
@@ -1,7 +1,3 @@
-import emberRequire from './-private/ext-require';
+import Engine from '@ember/engine';
 
-// Because feature flags are only valid for Ember canary builds,
-// `Ember.Engine` won't be exposed publicly for beta builds. This export
-// provides a means to use this module with any ember build which privately
-// includes the `engine` module.
-export default emberRequire('ember-application/system/engine');
+export default Engine;

--- a/tests/unit/engine-instance-test.js
+++ b/tests/unit/engine-instance-test.js
@@ -1,17 +1,14 @@
+import Ember from 'ember';
 import Application from '@ember/application';
 import { run } from '@ember/runloop';
 import EnginesInitializer from '../../initializers/engines';
 import Engine from 'ember-engines/engine';
-import emberRequire from 'ember-engines/-private/ext-require';
 import { module, test } from 'qunit';
 
 import Resolver from '../../resolver';
 import config from '../../config/environment';
 
-const getEngineParent = emberRequire(
-  'ember-application/system/engine-parent',
-  'getEngineParent'
-);
+const getEngineParent = Ember.__loader.require('ember-application/system/engine-parent').getEngineParent;
 
 let App, app, appInstance;
 


### PR DESCRIPTION
Prior to these changes we were using `Ember.__loader.require` to access private internal modules from Ember itself. This was done because at the time, `Ember.Engine` / `Ember.EngineInstance` / etc were not exported globally from Ember itself (during the engines initial feature flag period long ago).

This changes ember-engines to remove all non-testing usages of `Ember.__loader.require`, and therefore makes it much more resilient to changes in Embers own internal module structure.