### PR TITLE
add public API for reseting the `memoize` cache

### DIFF
--- a/addon/-private/link-to-utils.js
+++ b/addon/-private/link-to-utils.js
@@ -1,8 +1,8 @@
-import Ember from 'ember';
+import { VERSION } from '@ember/version'
 
 // LAME, but ¯\_(ツ)_/¯
 export default function hasEmberVersion(major, minor) {
-  var numbers = Ember.VERSION.split('-')[0].split('.');
+  var numbers = VERSION.split('-')[0].split('.');
   var actualMajor = parseInt(numbers[0], 10);
   var actualMinor = parseInt(numbers[1], 10);
   return actualMajor > major || (actualMajor === major && actualMinor >= minor);

--- a/lib/test-utils.js
+++ b/lib/test-utils.js
@@ -1,0 +1,9 @@
+const resetMemoize = require('./utils/memoize')._reset;
+
+/**
+ * Reset cached state (useful in tests).
+ * @public
+ */
+module.exports.resetCaches = function resetCaches() {
+  resetMemoize();
+};

--- a/lib/utils/memoize.js
+++ b/lib/utils/memoize.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const calculateCacheKeyForTree = require('calculate-cache-key-for-tree');
-const CACHE = Object.create(null);
+let CACHE = Object.create(null);
 
 module.exports = function memoize(func) {
   return function _memoize() {
@@ -12,4 +12,12 @@ module.exports = function memoize(func) {
       return (CACHE[cacheKey] = func.apply(this, arguments));
     }
   };
+};
+
+/**
+ * Reset cached state (useful in tests).
+ * @private
+ */
+module.exports._reset = function reset() {
+  CACHE = Object.create(null);
 };

--- a/node-tests/unit/utils/memoize-test.js
+++ b/node-tests/unit/utils/memoize-test.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const expect = require('chai').expect;
+const memoize = require('../../../lib/utils/memoize');
+const resetCaches = require('../../../lib/test-utils').resetCaches;
+
+describe('memoize', function() {
+  it('correctly memoizes functions', function() {
+    const context = {
+      pkg: {
+        name: 'package-name'
+      },
+
+      calls: [],
+
+      fn: memoize(function a() {
+        this.calls.push([].slice.call(arguments));
+        return 'cached value';
+      })
+    };
+
+    context.fn(4, 8);
+    expect(context.calls).to.deep.equal([
+      [4, 8]
+    ]);
+
+    context.fn(15, 16);
+    expect(context.calls).to.deep.equal([
+      [4, 8]
+    ]);
+
+    // exercise the test utility to ensure that we can clean up after ourselves
+    resetCaches();
+
+    context.fn(23, 42);
+    expect(context.calls).to.deep.equal([
+      [4, 8],
+      [23, 42],
+    ]);
+  });
+});


### PR DESCRIPTION
I encountered the need for this change when I tried writing a test for
an addon that interacts with ember-engines. The cache holds on to
broccoli trees, including their location on disk. I was using
[broccoli-test-helper][bth] which creates temp directories for each
test. Ember-engines would continue to refer to the previous test's
temp directories and fail in confusing ways. This new API allows me
to reset the caches between tests.

[bth]:https://github.com/broccolijs/broccoli-test-helper

@rwjblue 