### PR TITLE
Fix Ember version import

### DIFF
--- a/addon/-private/link-to-utils.js
+++ b/addon/-private/link-to-utils.js
@@ -1,8 +1,7 @@
-import { VERSION } from '@ember/version'
-
+import Ember from 'ember';
 // LAME, but ¯\_(ツ)_/¯
 export default function hasEmberVersion(major, minor) {
-  var numbers = VERSION.split('-')[0].split('.');
+  var numbers = Ember.VERSION.split('-')[0].split('.');
   var actualMajor = parseInt(numbers[0], 10);
   var actualMinor = parseInt(numbers[1], 10);
   return actualMajor > major || (actualMajor === major && actualMinor >= minor);


### PR DESCRIPTION
`Uncaught Error: Could not find module `@ember/version` imported from ` 


`import { VERSION } from '@ember/version';` Still not available on ember-cli@3.1.4