### PR TITLE
Allow importing from node_modules in lazy in-repo engines

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -41,14 +41,43 @@ const findHost = require('./utils/find-host');
 const findHostsHost = require('./utils/find-hosts-host');
 const processBabel = require('./utils/process-babel');
 const buildExternalTree = memoize(function buildExternalTree() {
+  let trees = [];
+
   let vendorPath = path.resolve(this.root, this.treePaths['vendor']);
-  if (!fs.existsSync(vendorPath)) {
-    return;
+  if (fs.existsSync(vendorPath)) {
+    trees.push(new Funnel(vendorPath, {
+      destDir: 'vendor',
+    }));
   }
 
-  return new Funnel(vendorPath, {
-    destDir: 'vendor',
+  let nodeModulesTrees = Array.from(this._nodeModules.values(), module => new Funnel(module.path, {
+    srcDir: '/',
+    destDir: `node_modules/${module.name}/`,
+    annotation: `Funnel (node_modules/${module.name})`,
+  }));
+
+  trees = trees.concat(...nodeModulesTrees);
+
+  let externalTree = mergeTrees(trees, {
+    annotation: 'TreeMerger (ExternalTree)',
+    overwrite: true,
   });
+
+  for (let customTransformEntry of this._customTransformsMap) {
+    let transformName = customTransformEntry[0];
+    let transformConfig = customTransformEntry[1];
+
+    let transformTree = new Funnel(externalTree, {
+      files: transformConfig.files,
+      annotation: `Funnel (custom transform: ${transformName})`,
+    });
+
+    externalTree = mergeTrees([externalTree, transformConfig.callback(transformTree, transformConfig.options)], {
+      annotation: `TreeMerger (custom transform: ${transformName})`,
+      overwrite: true,
+    });
+  }
+  return externalTree;
 });
 
 const buildVendorTree = memoize(function buildVendorTree() {
@@ -450,6 +479,7 @@ module.exports = {
       this.otherAssetPaths = [];
       this._scriptOutputFiles = {};
       this._styleOutputFiles = {};
+      this._nodeModules = new Map();
 
       // Determines if this Engine or any of its parents are lazy
       this._hasLazyAncestor = findHost.call(this) !== findRoot.call(this);
@@ -492,6 +522,11 @@ module.exports = {
           this.import(
             'engines-dist/' + this.name + '/assets/engine-vendor.css'
           );
+
+          let host = originalFindHost.call(this);
+          this._customTransformsMap = new Map();
+          this.shouldIncludeAddon = () => true;
+          host._importAddonTransforms.call(this);
         }
 
         /**

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -480,6 +480,8 @@ module.exports = {
       this._scriptOutputFiles = {};
       this._styleOutputFiles = {};
       this._nodeModules = new Map();
+      this._customTransformsMap = new Map();
+      this.shouldIncludeAddon = () => true;
 
       // Determines if this Engine or any of its parents are lazy
       this._hasLazyAncestor = findHost.call(this) !== findRoot.call(this);
@@ -524,8 +526,6 @@ module.exports = {
           );
 
           let host = originalFindHost.call(this);
-          this._customTransformsMap = new Map();
-          this.shouldIncludeAddon = () => true;
           host._importAddonTransforms.call(this);
         }
 

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -11,7 +11,7 @@ const DependencyFunnel = require('broccoli-dependency-funnel');
 const defaultsDeep = require('lodash/defaultsDeep');
 const calculateCacheKeyForTree = require('calculate-cache-key-for-tree');
 const Addon = require('ember-cli/lib/models/addon');
-const memoize = require('./utils/memoize');
+const { memoize } = require('./utils/memoize');
 const maybeMergeTrees = require('./utils/maybe-merge-trees');
 const p = require('ember-cli-preprocess-registry/preprocessors');
 const shouldCompactReexports = require('./utils/should-compact-reexports');
@@ -41,10 +41,11 @@ const findHost = require('./utils/find-host');
 const findHostsHost = require('./utils/find-hosts-host');
 const processBabel = require('./utils/process-babel');
 const buildExternalTree = memoize(function buildExternalTree() {
+  const treePath = this.treePaths['vendor'];
+  const vendorPath = treePath ? path.resolve(this.root, treePath) : null;
   let trees = [];
 
-  let vendorPath = path.resolve(this.root, this.treePaths['vendor']);
-  if (fs.existsSync(vendorPath)) {
+  if (vendorPath && fs.existsSync(vendorPath)) {
     trees.push(new Funnel(vendorPath, {
       destDir: 'vendor',
     }));
@@ -77,6 +78,7 @@ const buildExternalTree = memoize(function buildExternalTree() {
       overwrite: true,
     });
   }
+
   return externalTree;
 });
 

--- a/lib/utils/memoize.js
+++ b/lib/utils/memoize.js
@@ -3,13 +3,15 @@
 const calculateCacheKeyForTree = require('calculate-cache-key-for-tree');
 const CACHE = Object.create(null);
 
-module.exports = function memoize(func) {
-  return function _memoize() {
+function memoize(func) {
+  return function() {
     let cacheKey = calculateCacheKeyForTree(func.name, this);
     if (CACHE[cacheKey]) {
       return CACHE[cacheKey];
     } else {
       return (CACHE[cacheKey] = func.apply(this, arguments));
     }
-  };
-};
+  }
+}
+
+module.exports.memoize = memoize;

--- a/node-tests/unit/engine-addon-test.js
+++ b/node-tests/unit/engine-addon-test.js
@@ -1,11 +1,15 @@
 'use strict';
 
-const EngineAddon = require('../../lib/engine-addon');
 const expect = require('chai').expect;
+const sinon = require('sinon');
+const rewire = require('rewire');
 const path = require('path');
+const memoize = require('../../lib/utils/memoize');
 
 describe('engine-addon', function() {
   describe('engineConfig', function() {
+    const EngineAddon = require('../../lib/engine-addon');
+
     it('caches per environment', function() {
       // TODO: EngineAddon is crazy, it will need to be refactored to cleanup this test
       const addon = EngineAddon.extend({
@@ -31,6 +35,8 @@ describe('engine-addon', function() {
   });
 
   describe('updateFastBootManifest', function() {
+    const EngineAddon = require('../../lib/engine-addon');
+
     it('adds necessary vendorFiles to the manifest when lazyLoading is enabled', function() {
       const addon = EngineAddon.extend({
         name: 'testing',
@@ -69,6 +75,45 @@ describe('engine-addon', function() {
           'engines-dist/testing/config/environment.js',
         ],
       });
+    });
+  });
+
+  describe('buildExternalTree', function() {
+    const memoizeStub = sinon.stub(memoize, 'memoize').callsFake((func) => { return func; });
+    const EngineAddon = rewire('../../lib/engine-addon');
+    const buildExternalTree = EngineAddon.__get__('buildExternalTree');
+
+    beforeEach(function() {
+      this.treePaths = { vendor: 'config' };
+      this.root = path.join(__dirname, '../fixtures/engine-config/');
+      this._nodeModules = new Map();
+      this._customTransformsMap = new Map();
+
+      this._nodeModules.set('/mock/path/one', { name: 'mock-module-one', path: '/mock/path/one' });
+      this._nodeModules.set('/mock/path/two', { name: 'mock-module-two', path: '/mock/path/two' });
+      this._customTransformsMap.set('amd', {
+        files: [],
+        options: {},
+        callback: () => {},
+        processOptions: () => {}
+      });
+    });
+
+    after(function() {
+      memoizeStub.reset();
+    });
+
+    it('does not add vendor path if tree path is empty', function() {
+      this.treePaths = { vendor: 'doesNotExist' };
+      const tree = buildExternalTree.call(this);
+
+      expect(tree._inputNodes.length).to.equal(2);
+    });
+
+    it('adds vendor path, node modules and transforms to external trees', function() {
+      const tree = buildExternalTree.call(this);
+
+      expect(tree._inputNodes.length).to.equal(3);
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "loader.js": "^4.7.0",
     "mocha": "^5.2.0",
     "prettier": "^1.13.7",
+    "rewire": "^4.0.1",
     "walk-sync": "^0.3.1"
   },
   "keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,15 +50,32 @@ accepts@~1.3.4, accepts@~1.3.5:
     mime-types "~2.1.18"
     negotiator "0.6.1"
 
+acorn-jsx@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
+  integrity sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=
+  dependencies:
+    acorn "^3.0.4"
+
 acorn-jsx@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-4.1.1.tgz#e8e41e48ea2fe0c896740610ab6a4ffd8add225e"
   dependencies:
     acorn "^5.0.3"
 
+acorn@^3.0.4:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
+  integrity sha1-ReN/s56No/JbruP/U2niu18iAXo=
+
 acorn@^5.0.3, acorn@^5.1.1, acorn@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
+
+acorn@^5.5.0:
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
+  integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
 
 after@0.8.2:
   version "0.8.2"
@@ -78,9 +95,24 @@ agentkeepalive@^3.4.1:
   dependencies:
     humanize-ms "^1.2.1"
 
+ajv-keywords@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
+  integrity sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=
+
 ajv-keywords@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
+
+ajv@^5.2.3, ajv@^5.3.0:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
+  integrity sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
 
 ajv@^6.0.1, ajv@^6.5.0:
   version "6.5.2"
@@ -304,7 +336,7 @@ atob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
 
-babel-code-frame@^6.26.0:
+babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
   dependencies:
@@ -1702,6 +1734,11 @@ clone@^2.0.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
 
+co@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
+  integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
+
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
@@ -1795,7 +1832,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.4.7, concat-stream@^1.5.0:
+concat-stream@^1.4.7, concat-stream@^1.5.0, concat-stream@^1.6.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   dependencies:
@@ -1907,7 +1944,7 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cross-spawn@^5.0.1:
+cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   integrity sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=
@@ -2708,6 +2745,14 @@ eslint-plugin-prettier@^2.6.2:
     fast-diff "^1.1.1"
     jest-docblock "^21.0.0"
 
+eslint-scope@^3.7.1:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.3.tgz#bb507200d3d17f60247636160b4826284b108535"
+  integrity sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
 eslint-scope@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.0.tgz#50bf3071e9338bcdc43331794a0cb533f0136172"
@@ -2722,6 +2767,50 @@ eslint-utils@^1.3.0, eslint-utils@^1.3.1:
 eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+
+eslint@^4.19.1:
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.19.1.tgz#32d1d653e1d90408854bfb296f076ec7e186a300"
+  integrity sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==
+  dependencies:
+    ajv "^5.3.0"
+    babel-code-frame "^6.22.0"
+    chalk "^2.1.0"
+    concat-stream "^1.6.0"
+    cross-spawn "^5.1.0"
+    debug "^3.1.0"
+    doctrine "^2.1.0"
+    eslint-scope "^3.7.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^3.5.4"
+    esquery "^1.0.0"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.0.1"
+    ignore "^3.3.3"
+    imurmurhash "^0.1.4"
+    inquirer "^3.0.6"
+    is-resolvable "^1.0.0"
+    js-yaml "^3.9.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.4"
+    minimatch "^3.0.2"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.2"
+    pluralize "^7.0.0"
+    progress "^2.0.0"
+    regexpp "^1.0.1"
+    require-uncached "^1.0.3"
+    semver "^5.3.0"
+    strip-ansi "^4.0.0"
+    strip-json-comments "~2.0.1"
+    table "4.0.2"
+    text-table "~0.2.0"
 
 eslint@^5.1.0:
   version "5.3.0"
@@ -2767,6 +2856,14 @@ eslint@^5.1.0:
     table "^4.0.3"
     text-table "^0.2.0"
 
+espree@^3.5.4:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
+  integrity sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==
+  dependencies:
+    acorn "^5.5.0"
+    acorn-jsx "^3.0.0"
+
 espree@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/espree/-/espree-4.0.0.tgz#253998f20a0f82db5d866385799d912a83a36634"
@@ -2786,7 +2883,7 @@ esprima@~3.1.0:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
-esquery@^1.0.1:
+esquery@^1.0.0, esquery@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
   dependencies:
@@ -2969,7 +3066,7 @@ external-editor@^1.1.0:
     spawn-sync "^1.0.15"
     tmp "^0.0.29"
 
-external-editor@^2.1.0:
+external-editor@^2.0.4, external-editor@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
   dependencies:
@@ -2995,6 +3092,11 @@ extglob@^2.0.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
+
+fast-deep-equal@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
+  integrity sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=
 
 fast-deep-equal@^2.0.1:
   version "2.0.1"
@@ -3489,6 +3591,11 @@ global-prefix@^1.0.1:
     is-windows "^1.0.1"
     which "^1.2.14"
 
+globals@^11.0.1:
+  version "11.10.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.10.0.tgz#1e09776dffda5e01816b3bb4077c8b59c24eaa50"
+  integrity sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==
+
 globals@^11.7.0:
   version "11.7.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.7.0.tgz#a583faa43055b1aca771914bf68258e2fc125673"
@@ -3769,6 +3876,11 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
+ignore@^3.3.3:
+  version "3.3.10"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
+  integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
+
 ignore@^4.0.2:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.3.tgz#e2d58c9654d75b542529fa28d80ac95b29e4f467"
@@ -3833,6 +3945,26 @@ inquirer@^2:
     rx "^4.1.0"
     string-width "^2.0.0"
     strip-ansi "^3.0.0"
+    through "^2.3.6"
+
+inquirer@^3.0.6:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
+  integrity sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.0.4"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rx-lite "^4.0.8"
+    rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
     through "^2.3.6"
 
 inquirer@^5.2.0:
@@ -4076,7 +4208,7 @@ is-regex@^1.0.4:
   dependencies:
     has "^1.0.1"
 
-is-resolvable@^1.1.0:
+is-resolvable@^1.0.0, is-resolvable@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
 
@@ -4191,6 +4323,14 @@ js-yaml@^3.11.0, js-yaml@^3.2.5, js-yaml@^3.2.7, js-yaml@^3.6.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^3.9.1:
+  version "3.12.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.1.tgz#295c8632a18a23e054cf5c9d3cecafe678167600"
+  integrity sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
@@ -4211,6 +4351,11 @@ json-parse-better-errors@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
+
+json-schema-traverse@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
+  integrity sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
@@ -5863,6 +6008,11 @@ regexp.prototype.flags@^1.2.0:
   dependencies:
     define-properties "^1.1.2"
 
+regexpp@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-1.1.0.tgz#0e3516dd0b7904f413d2d4193dce4618c3a689ab"
+  integrity sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==
+
 regexpp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.0.tgz#b2a7534a85ca1b033bcf5ce9ff8e56d4e0755365"
@@ -5987,6 +6137,13 @@ retry@^0.10.0:
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
   integrity sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=
 
+rewire@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/rewire/-/rewire-4.0.1.tgz#ba1100d400a9da759fe599fc6e0233f0879ed6da"
+  integrity sha512-+7RQ/BYwTieHVXetpKhT11UbfF6v1kGhKFrtZN7UDL2PybMsSt/rpLWeEUGF5Ndsl1D5BxiCB14VDJyoX+noYw==
+  dependencies:
+    eslint "^4.19.1"
+
 right-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
@@ -6027,6 +6184,18 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   integrity sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=
   dependencies:
     aproba "^1.1.1"
+
+rx-lite-aggregates@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
+  integrity sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=
+  dependencies:
+    rx-lite "*"
+
+rx-lite@*, rx-lite@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
+  integrity sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=
 
 rx@^4.1.0:
   version "4.1.0"
@@ -6586,6 +6755,18 @@ symlink-or-copy@^1.0.0, symlink-or-copy@^1.0.1, symlink-or-copy@^1.1.3, symlink-
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symlink-or-copy/-/symlink-or-copy-1.2.0.tgz#5d49108e2ab824a34069b68974486c290020b393"
 
+table@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/table/-/table-4.0.2.tgz#a33447375391e766ad34d3486e6e2aedc84d2e36"
+  integrity sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==
+  dependencies:
+    ajv "^5.2.3"
+    ajv-keywords "^2.1.0"
+    chalk "^2.1.0"
+    lodash "^4.17.4"
+    slice-ansi "1.0.0"
+    string-width "^2.1.1"
+
 table@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/table/-/table-4.0.3.tgz#00b5e2b602f1794b9acaf9ca908a76386a7813bc"
@@ -6668,7 +6849,7 @@ text-encoding@^0.6.4:
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
 
-text-table@^0.2.0:
+text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 


### PR DESCRIPTION
Say we have a third-party asset we use only in a lazy-loaded in-repo engine, and we want to include it in the engine's bundle instead of the host app's. We try the normal ember app thing:
```js
// lib/my-lazy-engine/index.js

included(...args) {
  this._super(...args);

  this.import('node_modules/path/path/thingy.js', {
    using: [{ transformation: 'amd', as: 'thingy' }]
  });
}
```
This breaks three different ways:
1. Because it's in `node_modules`, [`EmberApp.import` tries to use `this._nodeModules`](https://github.com/ember-cli/ember-cli/blob/v3.1.4/lib/broccoli/ember-app.js#L1664-L1669), which doesn't exist.
1. Because it uses a `transformation`, [`EmberApp._import` tries to use `this._customTransformsMap`](https://github.com/ember-cli/ember-cli/blob/v3.1.4/lib/broccoli/ember-app.js#L1714), which doesn't exist.
1. After I added those, the asset wasn't actually output because `EngineAddon` clobbers the [relevant parts of `_processedExternalTree`](https://github.com/ember-cli/ember-cli/blob/v3.1.4/lib/broccoli/ember-app.js#L1157-L1177)

You'll notice all those links are to ember-cli 3.1.4. In ember-cli master, https://github.com/ember-cli/ember-cli/commit/a0b4693f032d29978e7d782eef08161fe5c139e9 changed the relevant internals in a way that breaks these changes (I assume it'll be released in 3.3?). Since ember-engines master is meant to track ember-cli master, I'm not sure you'll want to merge this PR. I figured I'd submit it anyway because it fixes a problem I (and others) have right now.

Also, not sure the best way to go about testing this. I didn't find any existing tests for `this.import`.

(Fixes #499, fixes #544)