### PR TITLE
fix: find-hosts-host 'Cannot read property 'enabled' of undefined'

### DIFF
--- a/lib/utils/find-hosts-host.js
+++ b/lib/utils/find-hosts-host.js
@@ -8,7 +8,7 @@ module.exports = function findHostsHost() {
   // Keep iterating upward until we don't have a grandparent.
   // Has to do this grandparent check because at some point we hit the project.
   do {
-    if (current.lazyLoading.enabled === true) {
+    if (current && current.lazyLoading && current.lazyLoading.enabled === true) {
       if (foundHost) {
         return current;
       }


### PR DESCRIPTION
Encountered this error with fresh install and in-repo-engine with lazyloading enabled. 

```
> ember serve

Could not start watchman
Visit https://ember-cli.com/user-guide/#watchman for more info.
Cannot read property 'enabled' of undefined
```

This error might be happening because I have another in-repo-addon.