### PR TITLE
Fix reduction of merge-trees

### DIFF
--- a/lib/utils/maybe-merge-trees.js
+++ b/lib/utils/maybe-merge-trees.js
@@ -9,16 +9,12 @@ const mergeTrees = require('ember-cli/lib/broccoli/merge-trees');
   @param {Array} _inputTrees an array of potential trees to merge
   @return {Tree|undefined}
 */
-module.exports = function maybeMergeTrees(_inputTrees, options) {
-  let inputTrees = _inputTrees.filter(Boolean);
-  if (inputTrees.length > 1) {
-    let merged = mergeTrees(inputTrees, options);
-    if (Array.isArray(merged._inputTrees) && merged._inputTrees.length === 0) {
-      // return undefined, as `mergeTrees` here is returning a merge of nothing
-      return;
-    }
-    return merged;
+module.exports = function maybeMergeTrees(inputTrees, options) {
+  const tree = Array.isArray(inputTrees) ? mergeTrees(inputTrees, options) : inputTrees;
+
+  if (mergeTrees.isEmptyTree(tree)) {
+    return undefined;
   } else {
-    return inputTrees[0];
+    return tree;
   }
 };

--- a/node-tests/unit/utils/maybe-merge-trees-test.js
+++ b/node-tests/unit/utils/maybe-merge-trees-test.js
@@ -2,6 +2,7 @@
 
 const expect = require('chai').expect;
 const maybeMergeTrees = require('../../../lib/utils/maybe-merge-trees');
+const mergeTrees = require('ember-cli/lib/broccoli/merge-trees');
 
 describe('maybeMergeTrees', function() {
 
@@ -10,9 +11,11 @@ describe('maybeMergeTrees', function() {
 
     let first = maybeMergeTrees([]);
     let second = maybeMergeTrees([]);
+    let third = maybeMergeTrees(mergeTrees([]));
 
     expect(first).to.equal(expected);
     expect(second).to.equal(expected);
+    expect(third).to.equal(expected);
   });
 
   it('returns the first item when merging single item array', function() {


### PR DESCRIPTION
- [x] @rwjblue r?
- [x] test

This correctly ignores empty trees..