### PR TITLE
fix: Use the tree passed to treeForAddon if provided.

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -84,10 +84,10 @@ const buildVendorCSSTree = memoize(function buildVendorCSSTree(vendorTree) {
   return this.debugTree(vendorCSSTree, 'vendor-style:input');
 });
 
-const buildEngineJSTree = memoize(function buildEngineJSTree() {
+const buildEngineJSTree = memoize(function buildEngineJSTree(tree) {
   let engineSourceTree;
   let treePath;
-  let addonTree = this.options.trees.addon;
+  let addonTree = tree || this.options.trees.addon;
 
   if (typeof addonTree === 'string') {
     treePath = path.resolve(this.root, addonTree);
@@ -120,8 +120,8 @@ const buildEngineJSTree = memoize(function buildEngineJSTree() {
 });
 
 const buildEngineJSTreeWithoutRoutes = memoize(
-  function buildEngineJSTreeWithoutRoutes() {
-    return new DependencyFunnel(buildEngineJSTree.call(this), {
+  function buildEngineJSTreeWithoutRoutes(tree) {
+    return new DependencyFunnel(buildEngineJSTree.call(this, tree), {
       exclude: true,
       entry: this.name + '/routes.js',
       external: ['ember-engines/routes'],
@@ -129,9 +129,9 @@ const buildEngineJSTreeWithoutRoutes = memoize(
   }
 );
 
-const buildEngineRoutesJSTree = memoize(function buildEngineRouteJSTree() {
+const buildEngineRoutesJSTree = memoize(function buildEngineRouteJSTree(tree) {
   // Get complete engine JS tree
-  let engineAppTree = buildEngineJSTree.call(this);
+  let engineAppTree = buildEngineJSTree.call(this, tree);
 
   // Separate routes
   let engineRoutesTree = new DependencyFunnel(engineAppTree, {
@@ -525,7 +525,7 @@ module.exports = {
       //
       // If the lazyLoading.includeRoutesInApplication option is false, we don't
       // want to promote the routes into the host.
-      this.treeForEngine = function() {
+      this.treeForEngine = function(tree) {
         let extractRoutes =
           this._hasLazyAncestor &&
           this.lazyLoading.includeRoutesInApplication !== false;
@@ -536,7 +536,7 @@ module.exports = {
         // The only thing that we want to promote from a lazy engine is the
         // routes.js file and all of its dependencies, which is why we build the
         // complete JS tree.
-        let completeJSTree = buildCompleteJSTree.call(this);
+        let completeJSTree = buildCompleteJSTree.call(this, tree);
 
         // Splice out the routes.js file and its dependencies.
         // We will push these into the host application.
@@ -552,7 +552,7 @@ module.exports = {
 
       // Replace `treeForAddon` so that we control how this engine gets built.
       // We may or may not want it to be combined like a default addon.
-      this.treeForAddon = function() {
+      this.treeForAddon = function(tree) {
         if (this.lazyLoading.enabled === true) {
           return;
         }
@@ -574,8 +574,8 @@ module.exports = {
         // remove the engine's routes file, because we've already accounted
         // for our route map file with the `treeForEngine` hook.
         let engineJSTree = this._hasLazyAncestor
-          ? buildEngineJSTreeWithoutRoutes.call(this)
-          : buildEngineJSTree.call(this);
+          ? buildEngineJSTreeWithoutRoutes.call(this, tree)
+          : buildEngineJSTree.call(this, tree);
 
         // Move the Engine tree to `modules`
         engineJSTree = new Funnel(engineJSTree, {


### PR DESCRIPTION
Brings engines closer in line with the behavior of regular addons. 

Some addons (including the `ember-engines` addon itself!) rely on the ability to override parent addons' `treeFor*` hooks and intercept trees before they are processed by the parent. Ex:

```javascript
// ... 
included(parent){
  let oldHook = parent.treeForAddon;
  parent.treeForAddon = (tree) => {
    tree = new DoSomething(tree);
    return oldHook.call(parent, tree);
  }
}
```

Ember engines currently throws out any tree passed to `treeForAddon` and creates it fresh from disk, breaking this convention.

I'm not entirely sure how to test this. Suggestions welcome. 

Also, this fix also only applies to eager engines – lazy engines are almost entirely implemented in the `treeForPublic` hook (why is that again?) and I believe will take a lot more work to enable this for.