### PR TITLE
Bump babel-plugin-compact-reexports

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   ],
   "dependencies": {
     "amd-name-resolver": "1.2.0",
-    "babel-plugin-compact-reexports": "^0.1.2",
+    "babel-plugin-compact-reexports": "^1.0.0",
     "broccoli-babel-transpiler": "^6.4.3",
     "broccoli-concat": "^3.4.0",
     "broccoli-debug": "^0.6.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -438,9 +438,9 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-compact-reexports@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-compact-reexports/-/babel-plugin-compact-reexports-0.1.2.tgz#15032cc06b1b9014fa7ec94bf9f12cca8344c9b0"
+babel-plugin-compact-reexports@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-compact-reexports/-/babel-plugin-compact-reexports-1.0.0.tgz#2b9034c79fe0b3a89c0846f147da281152f95489"
 
 babel-plugin-debug-macros@^0.1.10:
   version "0.1.11"


### PR DESCRIPTION
Which now correctly supports `import * from ‘foo’;`