### PR TITLE
Exclude fingerprinted environment files

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = ManifestGenerator.extend({
   name: 'ember-engines',
   manifestOptions: Object.freeze({
     bundlesLocation: 'engines-dist',
-    filesToIgnore: [/\/config\/environment.js$/],
+    filesToIgnore: [/\/config\/environment(?:-[\w\d]+)?\.js$/],
   }),
 
   /**


### PR DESCRIPTION
Enabling ember-cli's fingerprinting adds environment.js to engines' asset-manifest as `filesToIgnore` does not take the fingerprint into account.
This can be worked around be adding `config/environment.js` to the fingerprinting's `exclude` key but may be difficult to track down.