### PR TITLE
Deduplicate addons in lazy engines that are nested dependencies of the engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,11 @@ be loaded by the asset loading service. That will be generated at
 `/dist/asset-manifest.json` at build time. It will also by default be inserted
 into a meta tag config inside of the host application's `index.html`.
 
+#### Nested addon deduplication
+Use `EMBER_ENGINES_ADDON_DEDUPE` environment variable to deduplicate the nested
+addons of lazy engine which are also host app addons.
+More details at [#595](https://github.com/ember-engines/ember-engines/pull/595).
+
 ### Nested Eager Engines
 
 Nested eager engines will be built into their host engine or application.

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -249,6 +249,49 @@ const buildEngineStyleTree = memoize(function buildEngineStyleTree() {
   );
 });
 
+const recoverAddons = function recoverAddons(addon) {
+  if (addon._orginalAddons) {
+    addon.addons = addon._orginalAddons;
+  }
+
+  if (addon.addons.length > 0) {
+    addon.addons.forEach(recoverAddons)
+  }
+}
+
+const deeplyNonDuplicatedAddon = function deeplyNonDuplicatedAddon(hostAddons, addon, treeName) {
+  if (addon.addons.length === 0) {
+    return;
+  }
+
+  addon._orginalAddons = addon.addons;
+  addon.addons = addon.addons.filter(innerAddon => {
+    let shouldDeepDedup = !(innerAddon.lazyLoading && innerAddon.lazyLoading.enabled);
+
+    if (shouldDeepDedup && innerAddon.addons.length > 0) {
+      innerAddon._orginalAddons = innerAddon.addons;
+      deeplyNonDuplicatedAddon(hostAddons, innerAddon, treeName);
+    }
+
+    let hostAddon = hostAddons[innerAddon.name];
+
+    if (hostAddon && hostAddon.cacheKeyForTree) {
+      let innerCacheKey = innerAddon.cacheKeyForTree(treeName);
+      let hostAddonCacheKey = hostAddon.cacheKeyForTree(treeName);
+
+      if (
+        innerCacheKey != null &&
+        innerCacheKey === hostAddonCacheKey
+      ) {
+        // the addon specifies cache key and it is the same as host instance of the addon, skip the tree
+        return false;
+      }
+    }
+
+    return true;
+  });
+}
+
 module.exports = {
   extend(options) {
     let originalInit =
@@ -330,36 +373,27 @@ module.exports = {
       let invokeArguments = args || [];
       let hostAddons = this.ancestorHostAddons();
 
-      return this.addons
-        .map(addon => {
+      if (methodName === 'treeFor') {
+        deeplyNonDuplicatedAddon(hostAddons, this, invokeArguments[0]);
+      }
 
+      let trees = this.addons
+        .filter(addon => {
           if (!addon[methodName]) {
             // no method to call
-            return;
+            return false;
           }
-
-          let hostAddon = hostAddons[addon.name];
-
-          if (hostAddon && hostAddon.cacheKeyForTree) {
-            if (methodName === 'treeFor') {
-              let treeName = invokeArguments[0];
-              let hostAddonCacheKey = hostAddon.cacheKeyForTree(treeName);
-              let addonCacheKey = addon.cacheKeyForTree(treeName);
-
-              if (
-                addonCacheKey != null &&
-                addonCacheKey === hostAddonCacheKey
-              ) {
-                // the addon specifies cache key and it is the same as host instance of the addon, skip the tree
-                return;
-              }
-            } else {
-              return;
-            }
-          }
-
+          return true;
+        })
+        .map(addon => {
           return addon[methodName].apply(addon, invokeArguments);
-        }).filter(Boolean);
+        });
+
+      if (methodName === 'treeFor') {
+        recoverAddons(this);
+      }
+
+      return trees;
     };
 
     options.debugTree = BroccoliDebug.buildDebugCallback(

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -14,7 +14,7 @@ const Addon = require('ember-cli/lib/models/addon');
 const memoize = require('./utils/memoize');
 const maybeMergeTrees = require('./utils/maybe-merge-trees');
 const deeplyNonDuplicatedAddon = require('./utils/deeply-non-duplicated-addon');
-const recoverAddons = require('./utils/recover-addons');
+const restoreOriginalAddons = require('./utils/restore-original-addons');
 const p = require('ember-cli-preprocess-registry/preprocessors');
 const shouldCompactReexports = require('./utils/should-compact-reexports');
 const appendCompactReexportsIfNeeded = require('./utils/append-compact-reexports-if-needed');
@@ -332,28 +332,65 @@ module.exports = {
 
       let invokeArguments = args || [];
       let hostAddons = this.ancestorHostAddons();
+      let treeName = invokeArguments[0];
 
-      if (methodName === 'treeFor') {
-        deeplyNonDuplicatedAddon(hostAddons, this, invokeArguments[0]);
+      // methodName could be "treeFor" or "included"
+      // the "included" methodName will be handled in the old implementation for now
+      // TODO: when deeplyNonDuplicatedAddon is completely ready
+      // make sure that the "included" methodName is considered
+      if (process.env.EMBER_ENGINES_ADDON_DEDUPE && methodName === 'treeFor') {
+        let trees
+
+        try {
+          deeplyNonDuplicatedAddon(hostAddons, this, treeName);
+
+          trees = this.addons
+            .filter(addon => {
+              if (!addon[methodName]) {
+                // no method to call
+                return false;
+              }
+              return true;
+            })
+            .map(addon => {
+              return addon[methodName].apply(addon, invokeArguments);
+            });
+        } finally {
+          restoreOriginalAddons(this);
+        }
+
+        return trees
       }
 
-      let trees = this.addons
-        .filter(addon => {
+      // old implementation
+      return this.addons
+        .map(addon => {
           if (!addon[methodName]) {
             // no method to call
-            return false;
+            return;
           }
-          return true;
-        })
-        .map(addon => {
+
+          let hostAddon = hostAddons[addon.name];
+
+          if (hostAddon && hostAddon.cacheKeyForTree) {
+            if (methodName === 'treeFor') {
+              let hostAddonCacheKey = hostAddon.cacheKeyForTree(treeName);
+              let addonCacheKey = addon.cacheKeyForTree(treeName);
+
+              if (
+                addonCacheKey != null &&
+                addonCacheKey === hostAddonCacheKey
+              ) {
+                // the addon specifies cache key and it is the same as host instance of the addon, skip the tree
+                return;
+              }
+            } else {
+              return;
+            }
+          }
+
           return addon[methodName].apply(addon, invokeArguments);
-        });
-
-      if (methodName === 'treeFor') {
-        recoverAddons(this);
-      }
-
-      return trees;
+        }).filter(Boolean);
     };
 
     options.debugTree = BroccoliDebug.buildDebugCallback(

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -18,6 +18,7 @@ const recoverAddons = require('./utils/recover-addons');
 const p = require('ember-cli-preprocess-registry/preprocessors');
 const shouldCompactReexports = require('./utils/should-compact-reexports');
 const appendCompactReexportsIfNeeded = require('./utils/append-compact-reexports-if-needed');
+const ensureLazyLoadingHash = require('./utils/ensure-lazy-loading-hash');
 const preprocessCss = p.preprocessCss;
 const preprocessMinifyCss = p.preprocessMinifyCss;
 const BroccoliDebug = require('broccoli-debug');
@@ -378,13 +379,7 @@ module.exports = {
       this._engineConfig = new Map();
       this.options = defaultsDeep(options, DEFAULT_CONFIG);
 
-      // Ensure lazyLoading is a hash, retain backwards compatibility with using
-      // a boolean value
-      if (typeof this.lazyLoading === 'boolean') {
-        this.lazyLoading = {
-          enabled: this.lazyLoading,
-        };
-      }
+      ensureLazyLoadingHash(this);
 
       // NOTE: This is a beautiful hack to deal with core object calling toString on the function.
       // It'll throw a deprecation warning if this isn't present because it doesn't see a `_super`

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -13,6 +13,8 @@ const calculateCacheKeyForTree = require('calculate-cache-key-for-tree');
 const Addon = require('ember-cli/lib/models/addon');
 const memoize = require('./utils/memoize');
 const maybeMergeTrees = require('./utils/maybe-merge-trees');
+const deeplyNonDuplicatedAddon = require('./utils/deeply-non-duplicated-addon');
+const recoverAddons = require('./utils/recover-addons');
 const p = require('ember-cli-preprocess-registry/preprocessors');
 const shouldCompactReexports = require('./utils/should-compact-reexports');
 const appendCompactReexportsIfNeeded = require('./utils/append-compact-reexports-if-needed');
@@ -248,49 +250,6 @@ const buildEngineStyleTree = memoize(function buildEngineStyleTree() {
     'engine-style:input'
   );
 });
-
-const recoverAddons = function recoverAddons(addon) {
-  if (addon._orginalAddons) {
-    addon.addons = addon._orginalAddons;
-  }
-
-  if (addon.addons.length > 0) {
-    addon.addons.forEach(recoverAddons)
-  }
-}
-
-const deeplyNonDuplicatedAddon = function deeplyNonDuplicatedAddon(hostAddons, addon, treeName) {
-  if (addon.addons.length === 0) {
-    return;
-  }
-
-  addon._orginalAddons = addon.addons;
-  addon.addons = addon.addons.filter(innerAddon => {
-    let shouldDeepDedup = !(innerAddon.lazyLoading && innerAddon.lazyLoading.enabled);
-
-    if (shouldDeepDedup && innerAddon.addons.length > 0) {
-      innerAddon._orginalAddons = innerAddon.addons;
-      deeplyNonDuplicatedAddon(hostAddons, innerAddon, treeName);
-    }
-
-    let hostAddon = hostAddons[innerAddon.name];
-
-    if (hostAddon && hostAddon.cacheKeyForTree) {
-      let innerCacheKey = innerAddon.cacheKeyForTree(treeName);
-      let hostAddonCacheKey = hostAddon.cacheKeyForTree(treeName);
-
-      if (
-        innerCacheKey != null &&
-        innerCacheKey === hostAddonCacheKey
-      ) {
-        // the addon specifies cache key and it is the same as host instance of the addon, skip the tree
-        return false;
-      }
-    }
-
-    return true;
-  });
-}
 
 module.exports = {
   extend(options) {

--- a/lib/utils/deeply-non-duplicated-addon.js
+++ b/lib/utils/deeply-non-duplicated-addon.js
@@ -1,0 +1,44 @@
+'use strict';
+
+/**
+ * Deduplicate one addon's children addons recursively from hostAddons.
+ *
+ * @private
+ * @param {Object} hostAddons
+ * @param {EmberAddon} dedupedAddon
+ * @param {String} treeName
+ */
+module.exports = function deeplyNonDuplicatedAddon(hostAddons, dedupedAddon, treeName) {
+  if (dedupedAddon.addons.length === 0) {
+    return;
+  }
+
+  dedupedAddon._orginalAddons = dedupedAddon.addons;
+  dedupedAddon.addons = dedupedAddon.addons.filter(addon => {
+    if (addon.lazyLoading && addon.lazyLoading.enabled) {
+      return true;
+    }
+
+    if (addon.addons.length > 0) {
+      addon._orginalAddons = addon.addons;
+      deeplyNonDuplicatedAddon(hostAddons, addon, treeName);
+    }
+
+    let hostAddon = hostAddons[addon.name];
+
+    if (hostAddon && hostAddon.cacheKeyForTree) {
+      let innerCacheKey = addon.cacheKeyForTree(treeName);
+      let hostAddonCacheKey = hostAddon.cacheKeyForTree(treeName);
+
+      if (
+        innerCacheKey != null &&
+        innerCacheKey === hostAddonCacheKey
+      ) {
+        // the addon specifies cache key and it is the same as host instance of the addon, skip the tree
+        return false;
+      }
+    }
+
+    return true;
+  });
+}

--- a/lib/utils/deeply-non-duplicated-addon.js
+++ b/lib/utils/deeply-non-duplicated-addon.js
@@ -15,6 +15,7 @@ module.exports = function deeplyNonDuplicatedAddon(hostAddons, dedupedAddon, tre
 
   dedupedAddon._orginalAddons = dedupedAddon.addons;
   dedupedAddon.addons = dedupedAddon.addons.filter(addon => {
+    // nested lazy engine will have it's own deeplyNonDuplicatedAddon, just keep it here
     if (addon.lazyLoading && addon.lazyLoading.enabled) {
       return true;
     }

--- a/lib/utils/recover-addons.js
+++ b/lib/utils/recover-addons.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = function recoverAddons(addon) {
+  if (addon._orginalAddons) {
+    addon.addons = addon._orginalAddons;
+  }
+
+  if (addon.addons.length > 0) {
+    addon.addons.forEach(recoverAddons)
+  }
+}

--- a/lib/utils/restore-original-addons.js
+++ b/lib/utils/restore-original-addons.js
@@ -1,11 +1,11 @@
 'use strict';
 
-module.exports = function recoverAddons(addon) {
+module.exports = function restoreOriginalAddons(addon) {
   if (addon._orginalAddons) {
     addon.addons = addon._orginalAddons;
   }
 
   if (addon.addons.length > 0) {
-    addon.addons.forEach(recoverAddons)
+    addon.addons.forEach(restoreOriginalAddons)
   }
 }

--- a/node-tests/acceptance/dedupe-addons-test.js
+++ b/node-tests/acceptance/dedupe-addons-test.js
@@ -102,6 +102,7 @@ describe('Acceptance', function() {
     it(
       'in lazy engines that are nested dependencies of the engine',
       async function() {
+        process.env.EMBER_ENGINES_ADDON_DEDUPE = 1;
         let app = new AddonTestApp();
         let appName = 'engine-testing';
         let engineName = 'lazy';
@@ -184,6 +185,7 @@ describe('Acceptance', function() {
           `engines-dist/${engineName}/assets/engine-vendor.css`,
           cssCommentMatcher(`${addonName}.css`)
         );
+        delete process.env.EMBER_ENGINES_ADDON_DEDUPE;
       });
 
     it(

--- a/node-tests/acceptance/dedupe-addons-test.js
+++ b/node-tests/acceptance/dedupe-addons-test.js
@@ -99,7 +99,7 @@ describe('Acceptance', function() {
         );
       });
 
-    it.skip(
+    it(
       'in lazy engines that are nested dependencies of the engine',
       async function() {
         let app = new AddonTestApp();
@@ -165,7 +165,7 @@ describe('Acceptance', function() {
         // App folder should still be merged into the Engine's namespace
         output.contains(
           `engines-dist/${engineName}/assets/engine.js`,
-          moduleMatcher(`${engineName}/foo`)
+          reexportMatcher(`${addonName}/components/foo`, `${engineName}/foo`)
         );
 
         // All other files should not be included

--- a/node-tests/unit/utils/deeply-non-duplicated-addon-test.js
+++ b/node-tests/unit/utils/deeply-non-duplicated-addon-test.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const expect = require('chai').expect;
+const Addon = require('ember-cli/lib/models/addon');
+const EngineAddon = require('../../../lib/engine-addon');
+const deeplyNonDuplicatedAddon = require('../../../lib/utils/deeply-non-duplicated-addon');
+
+describe('deeplyNonDuplicatedAddon', function() {
+  let NestedAddonConstructor, LazyEngineConstructor, hostAddons, lazyEngine
+
+  beforeEach(function() {
+    NestedAddonConstructor = Addon.extend({
+      root: 'foo',
+      name: 'nested',
+    });
+
+    LazyEngineConstructor = Addon.extend(
+      Object.assign({
+        root: 'foo',
+        name: 'lazy',
+        lazyLoading: { enabled: true },
+      }, EngineAddon)
+    );
+
+    hostAddons = {
+      'nested': new NestedAddonConstructor(),
+    };
+
+    lazyEngine = new LazyEngineConstructor();
+  });
+
+  it('deduplicates children addons from hostAddons', function() {
+    let CommonAddonConstructor = Addon.extend({
+      root: 'foo',
+      name: 'common',
+    });
+
+    let commonAddon = new CommonAddonConstructor();
+    let commonAddonAddons = [new NestedAddonConstructor()];
+    commonAddon.addons = commonAddonAddons;
+
+    lazyEngine.addons = [commonAddon];
+
+    deeplyNonDuplicatedAddon(hostAddons, lazyEngine, 'addon');
+
+    expect(commonAddon.addons.length).to.equal(0);
+    expect(commonAddon._orginalAddons).to.equal(commonAddonAddons);
+  });
+
+  it('does not deduplicate children lazy engine addons from hostAddons', function() {
+    let NestedLazyEngineConstructor = Addon.extend(
+      Object.assign({
+        root: 'foo',
+        name: 'lazy-in-lazy',
+        lazyLoading: { enabled: true },
+      }, EngineAddon)
+    );
+
+    let nestedLazyEngine = new NestedLazyEngineConstructor();
+    let nestedLazyEngineAddons = [new NestedAddonConstructor()];
+    nestedLazyEngine.addons = nestedLazyEngineAddons;
+
+    lazyEngine.addons = [nestedLazyEngine];
+
+    deeplyNonDuplicatedAddon(hostAddons, lazyEngine, 'addon');
+
+    expect(nestedLazyEngine.addons).to.equal(nestedLazyEngineAddons);
+    expect(nestedLazyEngine._orginalAddons).to.be.undefined;
+  });
+
+});


### PR DESCRIPTION
Try to fix remaining "Shared addon deeper than engine" problem of https://github.com/ember-engines/ember-engines/pull/356.

An example of this problem copied from https://github.com/ember-engines/ember-engines/pull/356#issuecomment-288571816

> - project has dep on addon-derp
> - project has lazy engine engine-a
> - engine-a has engine addon-z
> - addon-z has addon-derp (addon-derp should not be duplicated)

For the example above, the `addon-derp` should not be duplicated, but without this PR it would be duplicated in the `vendor.js` of `engine-a`.

@rwjblue @trentmwillis @stefanpenner 