### PR TITLE
fix(route-ext): try `Route#_router` and `Route#router`

### DIFF
--- a/addon/-private/route-ext.js
+++ b/addon/-private/route-ext.js
@@ -7,7 +7,8 @@ import { getOwner } from '@ember/application';
 function externalAlias(methodName) {
   return function _externalAliasMethod(routeName, ...args) {
     let externalRoute = getOwner(this)._getExternalRoute(routeName);
-    return this.router[methodName](externalRoute, ...args);
+    let router = this._router || this.router;
+    return router[methodName](externalRoute, ...args);
   };
 }
 


### PR DESCRIPTION
Fixes #558.

As `Route#router` has been renamed `Route#_router` in Ember 3.6, `*ToExternal` is now broken. This PR fixes it by trying both keys.

https://github.com/emberjs/ember.js/commit/50a5a5df8172acbe6d287b1ba74b44485802eced#diff-7e252e0880a2b1de772cbcabaf3ddfb4L121