### PR TITLE
fix(engine-addon): only call `_requireBuildPackages`, if it exists

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -1022,7 +1022,9 @@ module.exports = {
       @return {Tree}
     */
     options.treeFor = function treeFor(name, source) {
-      this._requireBuildPackages();
+      // @TODO: remove once support for ember-cli@2.x is dropped.
+      // https://github.com/ember-cli/ember-cli/pull/8264
+      this._requireBuildPackages && this._requireBuildPackages();
 
       let cacheKey;
       if (HAS_TREE_CACHE) {


### PR DESCRIPTION
https://github.com/ember-cli/ember-cli/pull/8264 has removed `_requireBuildPackages` in [`v3.7.0`](https://github.com/ember-cli/ember-cli/releases/tag/v3.7.0), which has been a no-op since [`v3.0.0-beta.1`](https://github.com/ember-cli/ember-cli/releases/tag/v3.0.0-beta.1). This breaks ember-engines.