### PR TITLE
Fix find-host utils with lazyLoading hash

### DIFF
--- a/lib/utils/ensure-lazy-loading-hash.js
+++ b/lib/utils/ensure-lazy-loading-hash.js
@@ -1,0 +1,19 @@
+'use strict';
+
+/**
+ * Ensure lazyLoading is a hash, retain backwards compatibility with using a boolean value
+ *
+ * @private
+ * @param {Object} context
+ * @return {Object} lazyLoading
+ */
+
+module.exports = function ensureLazyLoginHash(context) {
+  if (typeof context.lazyLoading === 'boolean') {
+    context.lazyLoading = {
+      enabled: context.lazyLoading
+    };
+  }
+
+  return context;
+}

--- a/lib/utils/ensure-lazy-loading-hash.js
+++ b/lib/utils/ensure-lazy-loading-hash.js
@@ -5,7 +5,7 @@
  *
  * @private
  * @param {Object} context
- * @return {Object} lazyLoading
+ * @return {Object}
  */
 
 module.exports = function ensureLazyLoginHash(context) {

--- a/lib/utils/find-host.js
+++ b/lib/utils/find-host.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const ensureLazyLoagingHash = require('./ensure-lazy-loading-hash');
+
 module.exports = function findHost() {
   let current = this;
   let app;
@@ -7,6 +9,7 @@ module.exports = function findHost() {
   // Keep iterating upward until we don't have a grandparent.
   // Has to do this grandparent check because at some point we hit the project.
   do {
+    current = ensureLazyLoagingHash(current);
     if (current.lazyLoading.enabled === true) {
       return current;
     }

--- a/lib/utils/find-hosts-host.js
+++ b/lib/utils/find-hosts-host.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const ensureLazyLoagingHash = require('./ensure-lazy-loading-hash');
+
 module.exports = function findHostsHost() {
   let foundHost = false;
   let current = this;
@@ -8,6 +10,7 @@ module.exports = function findHostsHost() {
   // Keep iterating upward until we don't have a grandparent.
   // Has to do this grandparent check because at some point we hit the project.
   do {
+    current = ensureLazyLoagingHash(current);
     if (current.lazyLoading.enabled === true) {
       if (foundHost) {
         return current;

--- a/node-tests/unit/utils/ensure-lazy-loading-hash-test.js
+++ b/node-tests/unit/utils/ensure-lazy-loading-hash-test.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const expect = require('chai').expect;
+const ensureLazyLoadingHash = require('../../../lib/utils/ensure-lazy-loading-hash');
+
+describe('ensureLazyLoadingHash', function () {
+
+  it('returns a object with `enabled` key when lazyLoading is passed as boolean', function () {
+    let lazyLoading = { lazyLoading: true };
+
+    expect(ensureLazyLoadingHash(lazyLoading)).to.deep.equal({ lazyLoading: { enabled: true } });
+  });
+
+  it('returns the same object if lazyLoading is passed as object', function () {
+    let lazyLoading = { lazyLoading: { enabled: true } };
+
+    expect(ensureLazyLoadingHash(lazyLoading)).to.deep.equal({ lazyLoading: { enabled: true } });
+  });
+
+});


### PR DESCRIPTION
It's ensure that lazyLoading is a hash on `find-host` and `find-host-host` utils