### PR TITLE
Remove unnecessary file

### DIFF
--- a/addon/engine-instance.js
+++ b/addon/engine-instance.js
@@ -1,3 +1,0 @@
-import EngineInstance from '@ember/engines/instance';
-
-export default EngineInstance;


### PR DESCRIPTION
We have a test that validates all module exports in our codebase. While updating ember-engines from 0.5.16, the test threw an error `Could not find module @ember/engines/instance imported from ember-engines/engine-instance`.

If I am right, it should have been `@ember/engine/instance` instead of `@ember/engines/instance`.
I checked in ember.js repo as well and this seems to be a typo.

Since things are still working inspite of this typo, I believe this file is unnecessary.