### PR TITLE
Drop Node 4 support.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@
 
 # Test against these versions of Node.js.
 environment:
-  nodejs_version: "4"
+  nodejs_version: "6"
   matrix:
     - TEST_SCRIPT: test:windows
       EMBER_TRY_SCENARIO: ember-canary

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,6 @@ environment:
 install:
   - git rev-parse HEAD
   - npm version
-  - npm install phantomjs-prebuilt
   - npm install
 
 cache:

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "lodash": "^4.17.11"
   },
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": "6.* || 8.* || >= 10.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This was _effectively_ dropped in #619 (babel@7 requires Node 6+), but I wanted to make it more explicit.