### PR TITLE
Avoid errors when keywords array is not present.

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -416,7 +416,7 @@ module.exports = {
       }
 
       ['ember-addon', 'ember-engine'].forEach(keyword => {
-        if (this.pkg.keywords.indexOf(keyword) === -1) {
+        if (!this.pkg.keywords || this.pkg.keywords.indexOf(keyword) === -1) {
           this.ui.writeWarnLine(
             this.pkg.name +
               ` engine must specify "${keyword}" in the keywords section on package.json`

--- a/node-tests/unit/engine-addon-test.js
+++ b/node-tests/unit/engine-addon-test.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const EngineAddon = require('../../lib/engine-addon');
+const EmberAddon = require('ember-cli/lib/models/addon');
+const MockProject = require('ember-cli/tests/helpers/mock-project');
 const expect = require('chai').expect;
 const path = require('path');
 
@@ -27,6 +29,43 @@ describe('engine-addon', function() {
 
       expect(addon.engineConfig('test')).to.eql(addon.engineConfig('test'));
       expect(addon.engineConfig('bar')).to.eql(addon.engineConfig('bar'));
+    });
+  });
+
+  describe('keyword warning', function() {
+    let Addon, project, pkg;
+
+    beforeEach(function() {
+      pkg = {};
+
+      Addon = EmberAddon.extend(
+        EngineAddon.extend({
+          name: 'testing',
+          // eslint-disable-next-line ember/avoid-leaking-state-in-ember-objects
+          lazyLoading: { enabled: true }
+        })
+      );
+
+      Addon = Addon.extend({
+        root: path.join(__dirname, '../fixtures/engine-config/'),
+        pkg,
+      });
+
+      project = new MockProject();
+    });
+
+    it('warns to the console when pkg.keywords does not include ember-engines', function() {
+      pkg.keywords = ['ember-addon'];
+      new Addon(project, project);
+
+      expect(project.ui.output).to.include('keywords section');
+    });
+
+    it('warns to the console when pkg.keywords does not exist', function() {
+      pkg.keywords = undefined;
+      new Addon(project, project);
+
+      expect(project.ui.output).to.include('keywords section');
     });
   });
 


### PR DESCRIPTION
The recent addition of the keyword check throws an error (`Cannot read property 'indexOf' of undefined`) if keywords are not present. This fix ensures that the warning is issued either way (with or without a keywords array) and also adds tests that would have previously failed.