### PR TITLE
Ensure `postprocessTree` to ran before `broccoli-asset-rev`

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "node": "6.* || 8.* || >= 10.*"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "before": "broccoli-asset-rev"
   }
 }


### PR DESCRIPTION
Fixed the true scenario - https://github.com/ember-engines/ember-engines/pull/384#issuecomment-321823354

@rwjblue @dgeb 