### PR TITLE
fix(link-to): support angle-bracket invocation

### DIFF
--- a/addon/components/link-to-component.js
+++ b/addon/components/link-to-component.js
@@ -16,8 +16,11 @@ export default LinkComponent.extend({
     );
 
     if (owner.mountPoint) {
+      // https://emberjs.github.io/rfcs/0459-angle-bracket-built-in-components.html
+      const routeKey = 'targetRouteName' in this ? 'targetRouteName' : 'route';
+
       // Prepend engine mount point to targetRouteName
-      this._prefixProperty(owner.mountPoint, 'targetRouteName');
+      this._prefixProperty(owner.mountPoint, routeKey);
 
       // Prepend engine mount point to current-when if set
       if (get(this, 'current-when') !== null) {
@@ -55,5 +58,5 @@ export default LinkComponent.extend({
     } else {
       return prefix + '.' + propValue;
     }
-  },
+  }
 });

--- a/addon/components/link-to-external-component.js
+++ b/addon/components/link-to-external-component.js
@@ -9,9 +9,11 @@ export default LinkComponent.extend({
     const owner = getOwner(this);
 
     if (owner.mountPoint) {
-      const targetRouteName = get(this, 'targetRouteName');
-      const externalRoute = owner._getExternalRoute(targetRouteName);
-      set(this, 'targetRouteName', externalRoute);
+      // https://emberjs.github.io/rfcs/0459-angle-bracket-built-in-components.html
+      const routeKey = 'targetRouteName' in this ? 'targetRouteName' : 'route';
+      const routeName = get(this, routeKey);
+      const externalRoute = owner._getExternalRoute(routeName);
+      set(this, routeKey, externalRoute);
     }
-  },
+  }
 });

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-template-lint": "^1.0.0-beta.1",
     "ember-cli-uglify": "^2.1.0",
+    "ember-compatibility-helpers": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^2.0.0",

--- a/tests/integration/component-with-link-to-external-test.js
+++ b/tests/integration/component-with-link-to-external-test.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
-import { moduleForComponent, test } from 'ember-qunit';
+import { moduleForComponent, test, skip } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { gte } from 'ember-compatibility-helpers';
 
 moduleForComponent(
   'component-with-link-to-external',
@@ -11,11 +12,11 @@ moduleForComponent(
     beforeEach() {
       let testComponent = Component.extend();
       this.registry.register('component:test-component', testComponent);
-    },
+    }
   }
 );
 
-test('component renders with link-to-external', function(assert) {
+test('component renders with link-to-external [curly braces]', function(assert) {
   assert.expect(1);
 
   this.render(hbs`
@@ -27,3 +28,19 @@ test('component renders with link-to-external', function(assert) {
 
   assert.equal(this.$().length, 1);
 });
+
+(gte('3.10.0-beta.1') ? test : skip)(
+  'component renders with link-to-external [angle brackets]',
+  function(assert) {
+    assert.expect(1);
+
+    this.render(hbs`
+    <TestComponent>
+      <LinkTo @route="view">Link To</LinkTo>
+      <LinkToExternal @route="view">Link To External</LinkToExternal>
+    </TestComponent>
+  `);
+
+    assert.equal(this.$().length, 1);
+  }
+);

--- a/tests/unit/components/link-to-external-test.js
+++ b/tests/unit/components/link-to-external-test.js
@@ -1,12 +1,20 @@
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { gte } from 'ember-compatibility-helpers';
 
 module('Integration | Component | pretty color', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders properly', async function(assert) {
+  test('it renders properly [curly braces]', async function(assert) {
     await this.render(hbs`{{link-to-external 'home' 'home'}}`);
+    assert.equal(this.element.querySelector('a').textContent, 'home');
+  });
+
+  (gte('3.10.0-beta.1')
+    ? test
+    : skip)('it renders properly [angle brackets]', async function(assert) {
+    await this.render(hbs`<LinkToExternal @route='home'>home</LinkToExternal>`);
     assert.equal(this.element.querySelector('a').textContent, 'home');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1372,7 +1372,7 @@ babel-plugin-debug-macros@^0.1.10:
   dependencies:
     semver "^5.3.0"
 
-babel-plugin-debug-macros@^0.2.0-beta.6:
+babel-plugin-debug-macros@^0.2.0, babel-plugin-debug-macros@^0.2.0-beta.6:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz#0120ac20ce06ccc57bf493b667cf24b85c28da7a"
   integrity sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==
@@ -3496,7 +3496,7 @@ ember-cli-uglify@^2.1.0:
     broccoli-uglify-sourcemap "^2.1.1"
     lodash.defaultsdeep "^4.6.0"
 
-ember-cli-version-checker@^2.0.0, ember-cli-version-checker@^2.1.0, ember-cli-version-checker@^2.1.2:
+ember-cli-version-checker@^2.0.0, ember-cli-version-checker@^2.1.0, ember-cli-version-checker@^2.1.1, ember-cli-version-checker@^2.1.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz#47771b731fe0962705e27c8199a9e3825709f3b3"
   integrity sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==
@@ -3607,6 +3607,15 @@ ember-cli@~3.7.1:
     walk-sync "^1.0.0"
     watch-detector "^0.1.0"
     yam "^1.0.0"
+
+ember-compatibility-helpers@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.0.tgz#feee16c5e9ef1b1f1e53903b241740ad4b01097e"
+  integrity sha512-pUW4MzJdcaQtwGsErYmitFRs0rlCYBAnunVzlFFUBr4xhjlCjgHJo0b53gFnhTgenNM3d3/NqLarzRhDTjXRTg==
+  dependencies:
+    babel-plugin-debug-macros "^0.2.0"
+    ember-cli-version-checker "^2.1.1"
+    semver "^5.4.1"
 
 ember-disable-prototype-extensions@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
[RFC #0459](https://emberjs.github.io/rfcs/0459-angle-bracket-built-in-components.html) changed the attribute name from `targetRouteName` to `route`.

Here's the PR: https://github.com/emberjs/ember.js/pull/17772

This is currently breaking the Ember v3.10.0-beta series.