### PR TITLE
Fix "treeForVendor" for nested addon of lazyload engine

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -817,11 +817,16 @@ module.exports = {
 
         let vendorTree = buildVendorTree.call(this);
         let vendorJSTree = buildVendorJSTree.call(this, vendorTree);
-        let externalTree = new Funnel(vendorTree, {
-          srcDir: 'vendor',
-          destDir: 'vendor',
-          allowEmpty: true,
-        });
+        let externalTree = new Funnel(
+          mergeTrees(this.nonDuplicatedAddonInvoke('treeFor', ['vendor']), {
+            overwrite: true,
+            annotation: `Lazy-engine#treeFor (${options.name} vendor)`,
+          }),
+          {
+            destDir: 'vendor',
+            allowEmpty: true,
+          }
+        );
 
         let finalStylesTree = this.compileLazyEngineStyles(
           vendorTree,
@@ -1124,6 +1129,7 @@ module.exports = {
         name === 'app' ||
         name === 'styles' ||
         (name === 'addon' && this.lazyLoading.enabled === true) ||
+        (name === 'vendor' && this.lazyLoading.enabled === true) ||
         (name === 'public' && this.lazyLoading.enabled === true)
       ) {
         trees = [];

--- a/node-tests/acceptance/build-test.js
+++ b/node-tests/acceptance/build-test.js
@@ -433,6 +433,19 @@ describe('Acceptance', function() {
               },
             },
           },
+          prebuilt_vendor: {
+            'external_dependency.js': `define("external_dependency", ["exports"], function (_exports) {});`
+          },
+          'index.js': `module.exports = {
+             name: '${addonName}',
+             treeForVendor() {
+               return '${addon.path}/prebuilt_vendor';
+             },
+             included: function(app) {
+               this._super.included.apply(this, arguments);
+               app.import('vendor/external_dependency.js');
+             }
+           }`,
         });
 
         let output = await build(app);
@@ -451,6 +464,10 @@ describe('Acceptance', function() {
         output.contains(
           `engines-dist/${engineName}/assets/engine-vendor.js`,
           moduleMatcher(`${addonName}/templates/components/bar`)
+        );
+        output.contains(
+          `engines-dist/${engineName}/assets/engine-vendor.js`,
+          moduleMatcher('external_dependency')
         );
       });
 


### PR DESCRIPTION
Related issue https://github.com/ember-engines/ember-engines/issues/386

Repro: checkout https://github.com/2hu12/ember-engine-verification/tree/included-in-lazy-engine-addon and `yarn && ember build`, it will get an error like

> Error: ENOENT: no such file or directory, open '/tmp/broccoli-816153N6Pco04ZikZ/out-189-broccoli_debug_debug_12_engine_vendor_js/vendor/external_dependency_name.js'