### PR TITLE
[fix] prefix route name to `route` in <LinkTo>

### DIFF
--- a/addon/components/link-to-component.js
+++ b/addon/components/link-to-component.js
@@ -16,8 +16,13 @@ export default LinkComponent.extend({
     );
 
     if (owner.mountPoint) {
-      // Prepend engine mount point to targetRouteName
+      // [Ember <= 3.9] Prepend engine mount point to targetRouteName
+      // (for {{link-to "..."}})
       this._prefixProperty(owner.mountPoint, 'targetRouteName');
+
+      // [Ember >= 3.10] Prepend engine mount point to route
+      // (for <LinkTo @route="...">)
+      this._prefixProperty(owner.mountPoint, 'route');
 
       // Prepend engine mount point to current-when if set
       if (get(this, 'current-when') !== null) {

--- a/addon/components/link-to-external-component.js
+++ b/addon/components/link-to-external-component.js
@@ -9,8 +9,10 @@ export default LinkComponent.extend({
     const owner = getOwner(this);
 
     if (owner.mountPoint) {
-      const targetRouteName = get(this, 'targetRouteName');
+      // `route` for Ember >= 3.10, `targetRouteName` for Ember <= 3.9
+      const targetRouteName =  get(this, 'route') || get(this, 'targetRouteName');
       const externalRoute = owner._getExternalRoute(targetRouteName);
+      set(this, 'route', externalRoute);
       set(this, 'targetRouteName', externalRoute);
     }
   },


### PR DESCRIPTION
In ember-source 3.10, support for "angle bracket built-in" components like <LinkTo> was enabled. In the refactoring, the `targetRouteName` property was renamed to `_route `. This change overrides the `_route ` property to add the engine prefix (in addition to the original `targetRouteName` prefix, so that we continue to support Ember 3.9 and below.)

targetRouteName for curly {{link-to}} components:
https://github.com/emberjs/ember.js/blob/eee02fb72a47ff1ffbc9919fcf3fc4b74b937093/packages/%40ember/-internals/glimmer/lib/components/link-to.ts#L1765

_route for angle-bracket <LinkTo> components:
https://github.com/emberjs/ember.js/blob/eee02fb72a47ff1ffbc9919fcf3fc4b74b937093/packages/%40ember/-internals/glimmer/lib/components/link-to.ts#L490