### PR TITLE
Revert "ensure  to be ran before"

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "node": "6.* || 8.* || >= 10.*"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config",
-    "before": "broccoli-asset-rev"
+    "configPath": "tests/dummy/config"
   }
 }


### PR DESCRIPTION
This reverts commit e314a63dd51b6a21487490d0288afb90d5f729a0.

Reverting due to reports of production breakage in #632.  Specifically, the report was that this change resulted in _no_ fingerprinting being done for the asset manifest.

We need to investigate and figure out the right way to bring this back, I'll reopen the associated issue/PR so we can discuss it further.