### PR TITLE
Drop support for Node 6 and 11.

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "lodash": "^4.17.11"
   },
   "engines": {
-    "node": "6.* || 8.* || >= 10.*"
+    "node": "8.* || 10.* || >= 12.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
These platforms are both EOL'ed by the Node Foundation.