### PR TITLE
use ember-asset-loader v0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "broccoli-merge-trees": "^3.0.2",
     "broccoli-test-helper": "^2.0.0",
     "calculate-cache-key-for-tree": "^2.0.0",
-    "ember-asset-loader": "^0.6.0",
+    "ember-asset-loader": "^0.6.1",
     "ember-cli-babel": "^7.8.0",
     "ember-cli-preprocess-registry": "^3.3.0",
     "ember-cli-string-utils": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3273,10 +3273,10 @@ electron-to-chromium@^1.3.164, electron-to-chromium@^1.3.47:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.164.tgz#8680b875577882c1572c42218d53fa9ba5f71d5d"
   integrity sha512-VLlalqUeduN4+fayVtRZvGP2Hl1WrRxlwzh2XVVMJym3IFrQUS29BFQ1GP/BxOJXJI1OFCrJ5BnFEsAe8NHtOg==
 
-ember-asset-loader@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/ember-asset-loader/-/ember-asset-loader-0.6.0.tgz#d19481bf3d86e4d8116fec3d0f5ecccd0d1ed857"
-  integrity sha512-5avNE+2t7t1aZkWmJF5RwoX0ByQZpY5Hxwt5SIW1zPJeJDpBIFKovIpiuY1E3Um8gc12R52zPhqCpinbWFBzpA==
+ember-asset-loader@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/ember-asset-loader/-/ember-asset-loader-0.6.1.tgz#2eb81221406164d19127eba5b3d10f908df89a17"
+  integrity sha512-e2zafQJBMLhzl69caTG/+mQMH20uMHYrm7KcmdbmnX0oY2dZ48bhm0Wh1SPLXS/6G2T9NsNMWX6J2pVSnI+xyA==
   dependencies:
     broccoli-caching-writer "^3.0.3"
     broccoli-funnel "^2.0.2"


### PR DESCRIPTION
fix an error with .git when perform npm-install

See issue or PR on ember-asset-loader for more info:
https://github.com/ember-engines/ember-asset-loader/issues/83
https://github.com/ember-engines/ember-asset-loader/pull/84
