### PR TITLE
adding link-to route as a controller property instead of hardcoded string

### DIFF
--- a/tests/dummy/lib/ember-blog/addon/controllers/post.js
+++ b/tests/dummy/lib/ember-blog/addon/controllers/post.js
@@ -2,4 +2,5 @@ import Controller from '@ember/controller';
 
 export default Controller.extend({
   queryParams: ['lang'],
+  commentsRoute: 'post.comments'
 });

--- a/tests/dummy/lib/ember-blog/addon/templates/post.hbs
+++ b/tests/dummy/lib/ember-blog/addon/templates/post.hbs
@@ -5,7 +5,7 @@
 <p class="language">{{lang}}</p>
 
 <p>
-  {{#link-to "post.comments" 1 class="routable-post-comments-link"}}Comments{{/link-to}}
+  {{#link-to this.commentsRoute 1 class="routable-post-comments-link"}}Comments{{/link-to}}
   {{#link-to "post.likes" 1 class="routable-post-likes-link"}}Likes{{/link-to}}
   {{#link-to "post.diggs" 1 class="routable-post-diggs-link"}}Diggs{{/link-to}}
 </p>


### PR DESCRIPTION
Example of tests failing with `link-to` @buschtoens 
