### PR TITLE
fix link-to-component to not use set() to prefix route with `mountPoint`

### DIFF
--- a/addon/components/link-to-component.js
+++ b/addon/components/link-to-component.js
@@ -49,7 +49,8 @@ export default LinkComponent.extend({
       namespacedPropValue = this._namespacePropertyValue(prefix, propValue);
     }
 
-    set(this, prop, namespacedPropValue);
+    // cannot use `set()` to update property after using it in a computation
+    this[prop] = namespacedPropValue;
   },
 
   _namespacePropertyValue(prefix, propValue) {


### PR DESCRIPTION
Cannot use `set()` to prefix route property in `LinkComponent` when using ember octane.

Fixes issue #692