### PR TITLE
Include nested config meta + new default

### DIFF
--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -1035,17 +1035,13 @@ module.exports = {
       if (type === 'head') {
         let engineConfig = this.engineConfig(config.environment, {});
         let childrenConfig = this.eachAddonInvoke('contentFor', [type, config]);
+        let content = [];
 
-        let content =
-          '<meta name="' +
-          options.name +
-          '/config/environment" ' +
-          'content="' +
-          escape(JSON.stringify(engineConfig)) +
-          '" />';
+        if (engineConfig === {}) {
+          content.push(`<meta name="${options.name}'/config/environment" content="${escape(JSON.stringify(engineConfig))}" />`);
+        }
 
-        childrenConfig.push(content);
-        return childrenConfig.join('\n');
+        return content.concat(childrenConfig).join('\n');
       }
 
       return '';

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -1034,6 +1034,7 @@ module.exports = {
     options.contentFor = function(type, config) {
       if (type === 'head') {
         let engineConfig = this.engineConfig(config.environment, {});
+        let childrenConfig = this.eachAddonInvoke('contentFor', [type, config]);
 
         let content =
           '<meta name="' +
@@ -1043,7 +1044,8 @@ module.exports = {
           escape(JSON.stringify(engineConfig)) +
           '" />';
 
-        return content;
+        childrenConfig.push(content);
+        return childrenConfig.join('\n');
       }
 
       return '';

--- a/lib/engine-addon.js
+++ b/lib/engine-addon.js
@@ -1037,8 +1037,8 @@ module.exports = {
         let childrenConfig = this.eachAddonInvoke('contentFor', [type, config]);
         let content = [];
 
-        if (engineConfig === {}) {
-          content.push(`<meta name="${options.name}'/config/environment" content="${escape(JSON.stringify(engineConfig))}" />`);
+        if (Object.keys(engineConfig).length > 0) {
+          content.push(`<meta name="${options.name}/config/environment" content="${escape(JSON.stringify(engineConfig))}" />`);
         }
 
         return content.concat(childrenConfig).join('\n');

--- a/lib/engine-config-from-meta.js
+++ b/lib/engine-config-from-meta.js
@@ -1,14 +1,12 @@
-var config;
+var config = {};
+var metaElement = document.querySelector('meta[name="{{MODULE_PREFIX}}/config/environment"]');
 
-try {
-  var metaName = '{{MODULE_PREFIX}}/config/environment';
-  var rawConfig = document.querySelector('meta[name="' + metaName + '"]').getAttribute('content');
-  config = JSON.parse(unescape(rawConfig));
-}
-catch(err) {
-  // in the case where there is no meta tag we can default to an empty pojo
-  // instead of throwing an error
-  config = {};
+if (metaElement) {
+  try {
+    config = JSON.parse(unescape(metaElement.getAttribute('content')));
+  } catch (error) {
+    throw new Error('Could not read config from meta tag for `{{MODULE_PREFIX}}` due to an error:\n' + error);
+  }
 }
 
 export default config;

--- a/lib/engine-config-from-meta.js
+++ b/lib/engine-config-from-meta.js
@@ -6,7 +6,9 @@ try {
   config = JSON.parse(unescape(rawConfig));
 }
 catch(err) {
-  throw new Error('Could not read config from meta tag with name "' + metaName + '" due to error: ' + err);
+  // in the case where there is no meta tag we can default to an empty pojo
+  // instead of throwing an error
+  config = {};
 }
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@glimmer/component": "^1.0.0",
     "@glimmer/tracking": "^1.0.0",
     "babel-eslint": "^10.1.0",
+    "base-engine": "link:./tests/dummy/lib/base-engine",
     "broccoli-asset-rev": "^3.0.0",
     "chai": "^4.2.0",
     "common-tags": "^1.8.0",

--- a/tests/acceptance/base-nested-engine-test.js
+++ b/tests/acceptance/base-nested-engine-test.js
@@ -1,11 +1,11 @@
-import { module, test, only } from 'qunit';
+import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 
 module('Acceptance | base + nested engines', function(hooks) {
   setupApplicationTest(hooks);
 
-  only('visiting /base-engine', async function(assert) {
+  test('visiting /base-engine', async function(assert) {
     await visit('/base-engine');
 
     assert.equal(

--- a/tests/acceptance/base-nested-engine-test.js
+++ b/tests/acceptance/base-nested-engine-test.js
@@ -1,0 +1,24 @@
+import { module, test, only } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+
+module('Acceptance | base + nested engines', function(hooks) {
+  setupApplicationTest(hooks);
+
+  only('visiting /base-engine', async function(assert) {
+    await visit('/base-engine');
+
+    assert.equal(
+      unescape(document.querySelector('meta[name="base-engine/config/environment"]').content),
+      '{"modulePrefix":"base-engine","environment":"test"}'
+    );
+
+    assert.equal(
+      unescape(document.querySelector('meta[name="nested-engine/config/environment"]').content),
+      '{"modulePrefix":"nested-engine","environment":"test"}'
+    );
+
+    await visit('/base-engine/nested-engine');
+    assert.equal(currentURL(), '/base-engine/nested-engine');
+  });
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -8,6 +8,7 @@ export default class Router extends EmberRouter {
 
 Router.map(function() {
   this.route('routeless-engine-demo');
+  this.mount('base-engine');
 
   this.route('routable-engine-demo', function() {
     this.route('normal-route');

--- a/tests/dummy/lib/base-engine/.eslintrc
+++ b/tests/dummy/lib/base-engine/.eslintrc
@@ -1,0 +1,9 @@
+{
+  "parserOptions": {
+    "sourceType": "script"
+  },
+  "env": {
+    "node": true,
+    "browser": false,
+  },
+}

--- a/tests/dummy/lib/base-engine/addon/.eslintrc
+++ b/tests/dummy/lib/base-engine/addon/.eslintrc
@@ -1,0 +1,11 @@
+{
+  "parserOptions": {
+    "sourceType": "module"
+  },
+  "env": {
+    "node": false,
+    "browser": true
+  },
+  "rules": {
+  }
+}

--- a/tests/dummy/lib/base-engine/addon/engine.js
+++ b/tests/dummy/lib/base-engine/addon/engine.js
@@ -1,0 +1,15 @@
+import Engine from 'ember-engines/engine';
+import Resolver from 'ember-resolver';
+import loadInitializers from 'ember-load-initializers';
+import config from './config/environment';
+
+const { modulePrefix } = config;
+
+const Eng = Engine.extend({
+  modulePrefix,
+  Resolver,
+});
+
+loadInitializers(Eng, modulePrefix);
+
+export default Eng;

--- a/tests/dummy/lib/base-engine/addon/routes.js
+++ b/tests/dummy/lib/base-engine/addon/routes.js
@@ -1,0 +1,5 @@
+import buildRoutes from 'ember-engines/routes';
+
+export default buildRoutes(function() {
+  this.mount('nested-engine');
+});

--- a/tests/dummy/lib/base-engine/addon/templates/application.hbs
+++ b/tests/dummy/lib/base-engine/addon/templates/application.hbs
@@ -1,0 +1,3 @@
+<p>Base Engine</p>
+
+{{outlet}}

--- a/tests/dummy/lib/base-engine/config/environment.js
+++ b/tests/dummy/lib/base-engine/config/environment.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = function(environment) {
+  var ENV = {
+    modulePrefix: 'base-engine',
+    environment: environment,
+  };
+
+  return ENV;
+};

--- a/tests/dummy/lib/base-engine/index.js
+++ b/tests/dummy/lib/base-engine/index.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const EngineAddon = require('../../../../lib/engine-addon');
+
+module.exports = EngineAddon.extend({
+  name: 'base-engine',
+
+  isDevelopingAddon() {
+    return true;
+  },
+
+  hintingEnabled() {
+    return false;
+  },
+
+  lazyLoading: false,
+});

--- a/tests/dummy/lib/base-engine/package.json
+++ b/tests/dummy/lib/base-engine/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "base-engine",
+  "version": "0.0.0",
+  "keywords": [
+    "ember-addon",
+    "ember-engine"
+  ],
+  "dependencies": {
+    "ember-cli-babel": "*",
+    "ember-cli-htmlbars": "*",
+    "nested-engine": "link:../nested-engine"
+  }
+}

--- a/tests/dummy/lib/nested-engine/.eslintrc
+++ b/tests/dummy/lib/nested-engine/.eslintrc
@@ -1,0 +1,9 @@
+{
+  "parserOptions": {
+    "sourceType": "script"
+  },
+  "env": {
+    "node": true,
+    "browser": false,
+  },
+}

--- a/tests/dummy/lib/nested-engine/addon/.eslintrc
+++ b/tests/dummy/lib/nested-engine/addon/.eslintrc
@@ -1,0 +1,11 @@
+{
+  "parserOptions": {
+    "sourceType": "module"
+  },
+  "env": {
+    "node": false,
+    "browser": true
+  },
+  "rules": {
+  }
+}

--- a/tests/dummy/lib/nested-engine/addon/engine.js
+++ b/tests/dummy/lib/nested-engine/addon/engine.js
@@ -1,0 +1,15 @@
+import Engine from 'ember-engines/engine';
+import Resolver from 'ember-resolver';
+import loadInitializers from 'ember-load-initializers';
+import config from './config/environment';
+
+const { modulePrefix } = config;
+
+const Eng = Engine.extend({
+  modulePrefix,
+  Resolver,
+});
+
+loadInitializers(Eng, modulePrefix);
+
+export default Eng;

--- a/tests/dummy/lib/nested-engine/addon/routes.js
+++ b/tests/dummy/lib/nested-engine/addon/routes.js
@@ -1,0 +1,3 @@
+import buildRoutes from 'ember-engines/routes';
+
+export default buildRoutes(function() {});

--- a/tests/dummy/lib/nested-engine/addon/templates/application.hbs
+++ b/tests/dummy/lib/nested-engine/addon/templates/application.hbs
@@ -1,0 +1,1 @@
+<p>Nested Engine</p>

--- a/tests/dummy/lib/nested-engine/config/environment.js
+++ b/tests/dummy/lib/nested-engine/config/environment.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = function(environment) {
+  var ENV = {
+    modulePrefix: 'nested-engine',
+    environment: environment,
+  };
+
+  return ENV;
+};

--- a/tests/dummy/lib/nested-engine/index.js
+++ b/tests/dummy/lib/nested-engine/index.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const EngineAddon = require('../../../../lib/engine-addon');
+
+module.exports = EngineAddon.extend({
+  name: 'nested-engine',
+
+  isDevelopingAddon() {
+    return true;
+  },
+
+  hintingEnabled() {
+    return false;
+  },
+
+  lazyLoading: false,
+});

--- a/tests/dummy/lib/nested-engine/package.json
+++ b/tests/dummy/lib/nested-engine/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "nested-engine",
+  "version": "0.0.0",
+  "keywords": [
+    "ember-addon",
+    "ember-engine"
+  ],
+  "dependencies": {
+    "ember-cli-babel": "*",
+    "ember-cli-htmlbars": "*"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3213,6 +3213,10 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+"base-engine@link:./tests/dummy/lib/base-engine":
+  version "0.0.0"
+  uid ""
+
 base64-arraybuffer@0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
@@ -9593,6 +9597,10 @@ neo-async@^2.5.0, neo-async@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
+
+"nested-engine@link:tests/dummy/lib/nested-engine":
+  version "0.0.0"
+  uid ""
 
 nice-try@^1.0.4:
   version "1.0.5"


### PR DESCRIPTION
Nested engines config were not being included as meta tags + instead
of throwing an error when the meta tags are not included we default to
an empty pojo.

cc: @rwjblue 