### PR TITLE
Re-enable routeless engine container cleanup test.

### DIFF
--- a/packages/ember-engines/tests/acceptance/teardown-test.js
+++ b/packages/ember-engines/tests/acceptance/teardown-test.js
@@ -1,4 +1,4 @@
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 
@@ -20,8 +20,7 @@ test('routeable engines clean up their container state', async function(assert) 
   assert.ok(service.isDestroyed, 'service got destroyed');
 });
 
-// TODO: Unskip test after investigating issue with destroyables in ember 3.20
-skip('routeless engines clean up their container state', async function(assert) {
+test('routeless engines clean up their container state', async function(assert) {
   let service;
   assert.expect(2);
   this.application = startApp();


### PR DESCRIPTION
This test was disabled due to a failure on Ember 3.20.0, which has subsequently been fixed in Ember 3.20.5 (by https://github.com/emberjs/ember.js/pull/19106).

Closes #724