### PR TITLE
fix: findHost and findHostHost should allow undefined lazyLoading config

### DIFF
--- a/packages/ember-engines/lib/utils/ensure-lazy-loading-hash.js
+++ b/packages/ember-engines/lib/utils/ensure-lazy-loading-hash.js
@@ -10,13 +10,12 @@
 module.exports = function ensureLazyLoadingHash(context) {
   if (
     typeof context.lazyLoading === 'boolean' ||
-    typeof context.lazyLoading === 'undefined'
+    context.lazyLoading === undefined
   ) {
     context.lazyLoading = {
-      enabled: context.lazyLoading,
+      enabled: Boolean(context.lazyLoading),
     };
   }
 
   return context;
 };
-

--- a/packages/ember-engines/lib/utils/ensure-lazy-loading-hash.js
+++ b/packages/ember-engines/lib/utils/ensure-lazy-loading-hash.js
@@ -8,11 +8,15 @@
  * @return {Object}
  */
 module.exports = function ensureLazyLoadingHash(context) {
-  if (typeof context.lazyLoading === 'boolean') {
+  if (
+    typeof context.lazyLoading === 'boolean' ||
+    typeof context.lazyLoading === 'undefined'
+  ) {
     context.lazyLoading = {
-      enabled: context.lazyLoading
+      enabled: context.lazyLoading,
     };
   }
 
   return context;
-}
+};
+

--- a/packages/ember-engines/node-tests/unit/utils/ensure-lazy-loading-hash-test.js
+++ b/packages/ember-engines/node-tests/unit/utils/ensure-lazy-loading-hash-test.js
@@ -14,7 +14,7 @@ describe('ensureLazyLoadingHash', function () {
   it('returns a object with `enabled` key when lazyLoading is not passed', function () {
     let lazyLoading = {};
 
-    expect(ensureLazyLoadingHash(lazyLoading)).to.deep.equal({ lazyLoading: { enabled: undefined } });
+    expect(ensureLazyLoadingHash(lazyLoading)).to.deep.equal({ lazyLoading: { enabled: false } });
   });
 
   it('returns the same object if lazyLoading is passed as object', function () {

--- a/packages/ember-engines/node-tests/unit/utils/ensure-lazy-loading-hash-test.js
+++ b/packages/ember-engines/node-tests/unit/utils/ensure-lazy-loading-hash-test.js
@@ -11,6 +11,12 @@ describe('ensureLazyLoadingHash', function () {
     expect(ensureLazyLoadingHash(lazyLoading)).to.deep.equal({ lazyLoading: { enabled: true } });
   });
 
+  it('returns a object with `enabled` key when lazyLoading is not passed', function () {
+    let lazyLoading = {};
+
+    expect(ensureLazyLoadingHash(lazyLoading)).to.deep.equal({ lazyLoading: { enabled: undefined } });
+  });
+
   it('returns the same object if lazyLoading is passed as object', function () {
     let lazyLoading = { lazyLoading: { enabled: true } };
 


### PR DESCRIPTION
Normally engine's parent is the project and the findHost loop stops at
the first level dependency engine. If an engine's parent is another
engine it's also fine. However if the parent is an addon that did not
specify lazyLoading the build breaks saying cannot read enabled of
undefined.  This change allows addon uses engines for its dummy app.