### PR TITLE
Add mount prefix to route via computed instead of set

### DIFF
--- a/packages/ember-blog/addon/controllers/post.js
+++ b/packages/ember-blog/addon/controllers/post.js
@@ -3,6 +3,7 @@ import { set } from '@ember/object';
 
 export default Controller.extend({
   queryParams: ['lang'],
+  commentsRoute: 'post.comments', // Added to demonstrate that dynamic route names work
 
   actions: {
     transitionToHomeFromController() {

--- a/packages/ember-blog/addon/templates/post.hbs
+++ b/packages/ember-blog/addon/templates/post.hbs
@@ -5,7 +5,7 @@
 <p class="language">{{lang}}</p>
 
 <p>
-  {{#link-to "post.comments" 1 class="routable-post-comments-link"}}Comments{{/link-to}}
+  {{#link-to this.commentsRoute 1 class="routable-post-comments-link"}}Comments{{/link-to}}
   {{#link-to "post.likes" 1 class="routable-post-likes-link"}}Likes{{/link-to}}
   {{#link-to "post.diggs" 1 class="routable-post-diggs-link"}}Diggs{{/link-to}}
 </p>

--- a/packages/ember-engines/addon/components/link-to-component.js
+++ b/packages/ember-engines/addon/components/link-to-component.js
@@ -1,10 +1,25 @@
 import LinkComponent from '@ember/routing/link-component';
 import { getOwner } from '@ember/application';
-import { set, get } from '@ember/object';
+import { computed, get, set } from '@ember/object';
 import { typeOf } from '@ember/utils';
 import { assert } from '@ember/debug';
 
 export default LinkComponent.extend({
+  _route: computed('route', '_mountPoint', '_currentRouteState', function () {
+    let routeName = this._super(...arguments);
+    let mountPoint = get(this, '_mountPoint');
+
+    if (mountPoint && routeName !== get(this, '_currentRoute')) {
+      return this._namespacePropertyValue(mountPoint, routeName);
+    }
+
+    return routeName;
+  }),
+
+  _mountPoint: computed(function () {
+    return getOwner(this).mountPoint;
+  }),
+
   didReceiveAttrs() {
     this._super(...arguments);
 
@@ -16,11 +31,10 @@ export default LinkComponent.extend({
     );
 
     if (owner.mountPoint) {
-      // https://emberjs.github.io/rfcs/0459-angle-bracket-built-in-components.html
-      const routeKey = 'targetRouteName' in this ? 'targetRouteName' : 'route';
-
       // Prepend engine mount point to targetRouteName
-      this._prefixProperty(owner.mountPoint, routeKey);
+      if ('targetRouteName' in this) {
+        this._prefixProperty(owner.mountPoint, 'targetRouteName');
+      }
 
       // Prepend engine mount point to current-when if set
       if (get(this, 'current-when') !== null) {

--- a/packages/ember-engines/tests/acceptance/routeable-engine-demo-test.js
+++ b/packages/ember-engines/tests/acceptance/routeable-engine-demo-test.js
@@ -10,7 +10,7 @@ import { currentURL, visit, find, click } from '@ember/test-helpers';
 let originalExceptionHandler;
 let sinon;
 
-module('Acceptance | routeless engine demo', function (hooks) {
+module('Acceptance | routable engine demo', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(function () {


### PR DESCRIPTION
Fixes https://github.com/ember-engines/ember-engines/pull/668
Closes https://github.com/ember-engines/ember-engines/pull/693

https://github.com/ember-engines/ember-engines/pull/693 attempts to fix this same problem by avoiding a call to `set`, but I think that solution is not ideal as it is still adding side effects to `didReceiveAttrs`.

There is further potential for improvement here, but I only fixed the immediate issue I had so as to touch as small a surface as possible. Other possible areas where this fix may need to be replicated:

- `targetRouteName`
- `current-when`

Both of the above properties are ALSO `set` the same way `route` was, so it stands to reason that they may also have this same bug. We could try to fix them all here if you think it wise.

Similarly, `link-to-external` seems to have exactly the same problem and likely *also* needs this fix.

However, I was unable to figure out how to write a test that replicates this error - I took the reproduction from https://github.com/ember-engines/ember-engines/pull/668
I think the only way to make this work in a test is to write a wrapping component that holds the property and yields it to the `link-to` - apparently setting a property in the context of a test does not surface the same behavior protecting against modifications.

I can take a stab at the more complicated test setup tomorrow, but I wanted get this up for review to see if this even looked like the right approach. I have verified it in the demo app and ensured all broken tests were fixed as well.

cc: @rwjblue 