### PR TITLE
Support non-camelized engine names (deprecate camelization)

### DIFF
--- a/packages/ember-engines/tests/dummy/app/app.js
+++ b/packages/ember-engines/tests/dummy/app/app.js
@@ -8,7 +8,7 @@ export default class App extends Application {
   podModulePrefix = config.podModulePrefix;
   Resolver = Resolver;
   engines = {
-    emberBlog: {
+    'ember-blog': {
       dependencies: {
         services: [{ 'data-store': 'store' }],
         externalRoutes: {
@@ -16,7 +16,7 @@ export default class App extends Application {
         },
       },
     },
-    emberChat: {
+    'ember-chat': {
       dependencies: {
         services: ['store'],
       },

--- a/packages/ember-engines/tests/test-helper.js
+++ b/packages/ember-engines/tests/test-helper.js
@@ -5,6 +5,61 @@ import config from '../config/environment';
 
 import Application from '../app';
 import { setApplication } from '@ember/test-helpers';
+import { registerDeprecationHandler } from '@ember/debug';
+import QUnit from 'qunit';
+
 setApplication(Application.create(config.APP));
 
 preloadAssets(manifest).then(start); // This ensures all engine resources are loaded before the tests
+
+let deprecations;
+
+registerDeprecationHandler((message, options, next) => {
+  // In case a deprecation is issued before a test is started.
+  if (!deprecations) {
+    deprecations = [];
+  }
+
+  deprecations.push(message);
+  next(message, options);
+});
+
+QUnit.testStart(function () {
+  deprecations = [];
+});
+
+QUnit.assert.noDeprecations = function (callback) {
+  let originalDeprecations = deprecations;
+  deprecations = [];
+
+  callback();
+  this.deepEqual(deprecations, [], 'Expected no deprecations during test.');
+
+  deprecations = originalDeprecations;
+};
+
+QUnit.assert.deprecations = function (callback, expectedDeprecations) {
+  let originalDeprecations = deprecations;
+  deprecations = [];
+
+  callback();
+  this.deepEqual(deprecations, expectedDeprecations, 'Expected deprecations during test.');
+
+  deprecations = originalDeprecations;
+};
+
+QUnit.assert.deprecationsInclude = function (message) {
+  this.pushResult({
+    result: deprecations.indexOf(message) > -1,
+    actual: deprecations,
+    message: `Expected to find \`${message}\` deprecation.`,
+  });
+};
+
+QUnit.assert.deprecationsExclude = function (message) {
+  this.pushResult({
+    result: deprecations.indexOf(message) === -1,
+    actual: deprecations,
+    message: `Expected to not find \`${message}\` deprecation.`,
+  });
+};


### PR DESCRIPTION
Closes #625.

I'm guessing some of the deprecation details can be improved (id, message, ...).