### PR TITLE
[BUGFIX LTS] override assertLinkToOrigin method to noop in ember-engines

### DIFF
--- a/packages/ember-engines/addon/components/link-to-external.js
+++ b/packages/ember-engines/addon/components/link-to-external.js
@@ -13,6 +13,10 @@ if (gte('ember-source', '3.24.0-alpha.1')) {
 
       return externalRoute;
     }
+
+    // override LinkTo's assertLinkToOrigin method to noop. In LinkTo, this assertion
+    // checks to make sure LinkTo is not being used inside a routeless engine
+    assertLinkToOrigin() {}
   };
 } else {
   LinkToExternal = LinkComponent.extend({

--- a/packages/ember-engines/addon/components/link-to-external.js
+++ b/packages/ember-engines/addon/components/link-to-external.js
@@ -16,6 +16,7 @@ if (gte('ember-source', '3.24.0-alpha.1')) {
 
     // override LinkTo's assertLinkToOrigin method to noop. In LinkTo, this assertion
     // checks to make sure LinkTo is not being used inside a routeless engine
+    // See this PR here for more details: https://github.com/emberjs/ember.js/pull/19477
     assertLinkToOrigin() {}
   };
 } else {


### PR DESCRIPTION
This PR extends off the work done in ember.js repo here: https://github.com/emberjs/ember.js/pull/19477/files

since LinkToExternal extends LinkTo, we only want to run the assertion around using LinkTo inside of a routeless engine in the LinkTo class, and not the extension of LinkToExternal.