### PR TITLE
Add deprecation warning to router service from host

### DIFF
--- a/packages/ember-engines/addon/-private/engine-instance-ext.js
+++ b/packages/ember-engines/addon/-private/engine-instance-ext.js
@@ -1,6 +1,7 @@
 import { camelize } from '@ember/string';
 import { assert, deprecate } from '@ember/debug';
 import EngineInstance from '@ember/engine/instance';
+import { deprecate } from '@ember/debug';
 
 EngineInstance.reopen({
   /**
@@ -102,6 +103,18 @@ EngineInstance.reopen({
 
                 let dependencyKey = `${dependencyType}:${dependencyNameInParent}`;
                 let dependency = this.lookup(dependencyKey);
+
+                deprecate(
+                  `Support for the host's router service has been deprecated. Please use a different name as 'hostRouter' or 'appRouter' instead of '${dependencyName}'.`,
+                  category === 'services' && dependencyName === 'router',
+                  {
+                    id: 'ember-engines.deprecation-router-service-from-host',
+                    for: 'ember-engines',
+                    until: '0.9.0',
+                    since: {
+                      enabled: '0.8.13',
+                    },
+                  });
 
                 assert(
                   `Engine parent failed to lookup '${dependencyKey}' dependency, as declared in 'engines.${engineConfigurationKey}.dependencies.${category}'.`,

--- a/packages/ember-engines/addon/-private/engine-instance-ext.js
+++ b/packages/ember-engines/addon/-private/engine-instance-ext.js
@@ -64,7 +64,9 @@ EngineInstance.reopen({
   },
 
   lookup(fullName, options) {
-    deprecateHostRouterService(fullName);
+    if (fullName === 'router') {
+      deprecateHostRouterService(fullName);
+    }
     return this._super(fullName, options);
   },
 

--- a/packages/ember-engines/addon/-private/engine-instance-ext.js
+++ b/packages/ember-engines/addon/-private/engine-instance-ext.js
@@ -2,9 +2,9 @@ import { camelize } from '@ember/string';
 import { assert, deprecate } from '@ember/debug';
 import EngineInstance from '@ember/engine/instance';
 
-function deprecateHostRouterService(routerName) {
+function deprecateHostRouterService() {
   deprecate(
-    `Support for the host's router service has been deprecated. Please use a different name as 'hostRouter' or 'appRouter' instead of '${routerName}'.`,
+    `Support for the host's router service has been deprecated. Please use a different name as 'hostRouter' or 'appRouter' instead of 'router'.`,
     false,
     {
       id: 'ember-engines.deprecation-router-service-from-host',
@@ -64,8 +64,8 @@ EngineInstance.reopen({
   },
 
   lookup(fullName, options) {
-    if (fullName === 'router') {
-      deprecateHostRouterService(fullName);
+    if (['service:router', 'router:main'].includes(fullName)) {
+      deprecateHostRouterService();
     }
     return this._super(fullName, options);
   },
@@ -126,7 +126,7 @@ EngineInstance.reopen({
                 let dependency = this.lookup(dependencyKey);
 
                 if (category === 'services' && dependencyName === 'router') {
-                  deprecateHostRouterService(dependencyName);
+                  deprecateHostRouterService();
                 }
 
                 assert(

--- a/packages/ember-engines/addon/-private/engine-instance-ext.js
+++ b/packages/ember-engines/addon/-private/engine-instance-ext.js
@@ -13,7 +13,7 @@ function deprecateHostRouterService(routerName) {
       url: 'https://ember-engines.com/docs/deprecations#host-router-service',
       since: {
         enabled: '0.8.13',
-      },
+      }
     });
 }
 

--- a/packages/ember-engines/addon/-private/engine-instance-ext.js
+++ b/packages/ember-engines/addon/-private/engine-instance-ext.js
@@ -63,13 +63,6 @@ EngineInstance.reopen({
     this._externalRoutes = {};
   },
 
-  lookup(fullName, options) {
-    if (['service:router', 'router:main'].includes(fullName)) {
-      deprecateHostRouterService();
-    }
-    return this._super(fullName, options);
-  },
-
   buildChildEngineInstance(name, options = {}) {
     // Check dependencies cached by engine name
     let dependencies =

--- a/packages/ember-engines/addon/-private/engine-instance-ext.js
+++ b/packages/ember-engines/addon/-private/engine-instance-ext.js
@@ -2,6 +2,21 @@ import { camelize } from '@ember/string';
 import { assert, deprecate } from '@ember/debug';
 import EngineInstance from '@ember/engine/instance';
 
+function deprecateHostRouterService(routerName) {
+  deprecate(
+    `Support for the host's router service has been deprecated. Please use a different name as 'hostRouter' or 'appRouter' instead of '${routerName}'.`,
+    false,
+    {
+      id: 'ember-engines.deprecation-router-service-from-host',
+      for: 'ember-engines',
+      until: '0.9.0',
+      url: 'https://ember-engines.com/docs/deprecations#host-router-service',
+      since: {
+        enabled: '0.8.13',
+      },
+    });
+}
+
 EngineInstance.reopen({
   /**
     The root DOM element of the `EngineInstance` as an element or a
@@ -46,6 +61,11 @@ EngineInstance.reopen({
     this._super(...arguments);
 
     this._externalRoutes = {};
+  },
+
+  lookup(fullName, options) {
+    deprecateHostRouterService(fullName);
+    return this._super(fullName, options);
   },
 
   buildChildEngineInstance(name, options = {}) {
@@ -103,18 +123,9 @@ EngineInstance.reopen({
                 let dependencyKey = `${dependencyType}:${dependencyNameInParent}`;
                 let dependency = this.lookup(dependencyKey);
 
-                deprecate(
-                  `Support for the host's router service has been deprecated. Please use a different name as 'hostRouter' or 'appRouter' instead of '${dependencyName}'.`,
-                  category === 'services' && dependencyName === 'router',
-                  {
-                    id: 'ember-engines.deprecation-router-service-from-host',
-                    for: 'ember-engines',
-                    until: '0.9.0',
-                    url: 'https://ember-engines.com/docs/deprecations#host-router-service',
-                    since: {
-                      enabled: '0.8.13',
-                    },
-                  });
+                if (category === 'services' && dependencyName === 'router') {
+                  deprecateHostRouterService(dependencyName);
+                }
 
                 assert(
                   `Engine parent failed to lookup '${dependencyKey}' dependency, as declared in 'engines.${engineConfigurationKey}.dependencies.${category}'.`,

--- a/packages/ember-engines/addon/-private/engine-instance-ext.js
+++ b/packages/ember-engines/addon/-private/engine-instance-ext.js
@@ -10,7 +10,7 @@ function deprecateHostRouterService() {
       id: 'ember-engines.deprecation-router-service-from-host',
       for: 'ember-engines',
       until: '0.9.0',
-      url: 'https://ember-engines.com/docs/deprecations#host-router-service',
+      url: 'https://ember-engines.com/docs/deprecations#-use-alias-for-inject-router-service-from-host-application',
       since: {
         enabled: '0.8.13',
       }

--- a/packages/ember-engines/addon/-private/engine-instance-ext.js
+++ b/packages/ember-engines/addon/-private/engine-instance-ext.js
@@ -110,6 +110,7 @@ EngineInstance.reopen({
                     id: 'ember-engines.deprecation-router-service-from-host',
                     for: 'ember-engines',
                     until: '0.9.0',
+                    url: 'https://ember-engines.com/docs/deprecations#host-router-service',
                     since: {
                       enabled: '0.8.13',
                     },

--- a/packages/ember-engines/addon/-private/engine-instance-ext.js
+++ b/packages/ember-engines/addon/-private/engine-instance-ext.js
@@ -1,7 +1,6 @@
 import { camelize } from '@ember/string';
 import { assert, deprecate } from '@ember/debug';
 import EngineInstance from '@ember/engine/instance';
-import { deprecate } from '@ember/debug';
 
 EngineInstance.reopen({
   /**

--- a/packages/ember-engines/tests/unit/engine-instance-test.js
+++ b/packages/ember-engines/tests/unit/engine-instance-test.js
@@ -119,7 +119,7 @@ test('it can build a child engine instance with dependencies', function(
 test('it deprecates support for `router` service from host', function(
   assert
 ) {
-  assert.expect(4);
+  assert.expect(2);
 
   let BlogEngine = Engine.extend({
     router: null,
@@ -148,22 +148,6 @@ test('it deprecates support for `router` service from host', function(
   assert.deprecationsInclude(
     `Support for the host's router service has been deprecated. Please use a different name as 'hostRouter' or 'appRouter' instead of 'router'.`
   );
-
-  return blogEngineInstance.boot().then(() => {
-    blogEngineInstance.lookup('service:router');
-
-    assert.deprecationsInclude(
-      `Support for the host's router service has been deprecated. Please use a different name as 'hostRouter' or 'appRouter' instead of 'router'.`,
-    );
-    
-    // app router from root application
-    blogEngineInstance.lookup('router:main');
-
-    assert.deprecationsInclude(
-      `Support for the host's router service has been deprecated. Please use a different name as 'hostRouter' or 'appRouter' instead of 'router'.`,
-    );
-  });
-  
 });
 
 test('it can build a child engine instance with dependencies that are aliased', function(

--- a/packages/ember-engines/tests/unit/engine-instance-test.js
+++ b/packages/ember-engines/tests/unit/engine-instance-test.js
@@ -119,7 +119,7 @@ test('it can build a child engine instance with dependencies', function(
 test('it deprecates support for `router` service from host', function(
   assert
 ) {
-  assert.expect(3);
+  assert.expect(4);
 
   let BlogEngine = Engine.extend({
     router: null,
@@ -151,6 +151,13 @@ test('it deprecates support for `router` service from host', function(
 
   return blogEngineInstance.boot().then(() => {
     blogEngineInstance.lookup('service:router');
+
+    assert.deprecationsInclude(
+      `Support for the host's router service has been deprecated. Please use a different name as 'hostRouter' or 'appRouter' instead of 'router'.`,
+    );
+    
+    // app router from root application
+    blogEngineInstance.lookup('router:main');
 
     assert.deprecationsInclude(
       `Support for the host's router service has been deprecated. Please use a different name as 'hostRouter' or 'appRouter' instead of 'router'.`,

--- a/packages/ember-engines/tests/unit/engine-instance-test.js
+++ b/packages/ember-engines/tests/unit/engine-instance-test.js
@@ -116,6 +116,49 @@ test('it can build a child engine instance with dependencies', function(
   });
 });
 
+test('it deprecates support for `router` service from host', function(
+  assert
+) {
+  assert.expect(3);
+
+  let BlogEngine = Engine.extend({
+    router: null,
+    dependencies: Object.freeze({
+      services: ['router'],
+    }),
+  });
+
+  app.engines = {
+    blog: {
+      dependencies: {
+        services: ['router'],
+      },
+    },
+  };
+
+  app.register('engine:blog', BlogEngine);
+
+  let appInstance = app.buildInstance();
+  appInstance.setupRegistry();
+
+  let blogEngineInstance = appInstance.buildChildEngineInstance('blog');
+
+  assert.ok(blogEngineInstance);
+
+  assert.deprecationsInclude(
+    `Support for the host's router service has been deprecated. Please use a different name as 'hostRouter' or 'appRouter' instead of 'router'.`
+  );
+
+  return blogEngineInstance.boot().then(() => {
+    blogEngineInstance.lookup('service:router');
+
+    assert.deprecationsInclude(
+      `Support for the host's router service has been deprecated. Please use a different name as 'hostRouter' or 'appRouter' instead of 'router'.`,
+    );
+  });
+  
+});
+
 test('it can build a child engine instance with dependencies that are aliased', function(
   assert
 ) {


### PR DESCRIPTION
It creates a deprecation warning to #756 starting the addition of _Engine Router Service._ 

Also, it provides suggestions for how to register the host's router as **hostRouter** and/or the root router as **appRouter**. 


Deprecations page has been linked - https://github.com/ember-engines/ember-engines.com/pull/111