### PR TITLE
Support addon bundle caching as part of `ancestorHostAddons`

### DIFF
--- a/packages/ember-engines/lib/engine-addon.js
+++ b/packages/ember-engines/lib/engine-addon.js
@@ -60,7 +60,7 @@ try {
   // we only want to handle the error when this module isn't found; i.e.,
   // when a consumer of `ember-engines` is using an old version of `ember-cli`
   // (less than `ember-cli` 3.28)
-  if (!e || !e.message || !e.message.startsWith('Cannot find module')) {
+  if (!e || e.code !== 'MODULE_NOT_FOUND') {
     throw e;
   }
 }
@@ -365,12 +365,11 @@ function buildEngine(options) {
 
       hostAddons[addon.name] = addon;
 
-      queue.push.apply(
-        queue,
-        TARGET_INSTANCE_SYMBOL && addon[TARGET_INSTANCE_SYMBOL]
-          ? addon[TARGET_INSTANCE_SYMBOL].addons
-          : addon.addons
-      );
+      let addons = TARGET_INSTANCE_SYMBOL && addon[TARGET_INSTANCE_SYMBOL]
+        ? addon[TARGET_INSTANCE_SYMBOL].addons
+        : addon.addons;
+
+      queue.push(...addons);
     }
 
     this._hostAddons = hostAddons;


### PR DESCRIPTION
This adds support for bundle addon caching as part of `ember-cli`; specifically, we need to access the real/target instance in the event we're seeing a proxy as part of `ancestorHostAddons`. If we don't do this, the host addons won't be correct, since as part of this optimization `ember-cli` returns an empty array for `addons`. The main reason for this is that `ember-engines` dedupe is _stateful_: it's possible for `_orginalAddons` to be clobbered by `addons` again so the real original addons will never be restored as part of `restoreOriginalAddons`, producing a build that's broken/incorrect.

For more information, see the PR adding this to `ember-cli`: https://github.com/ember-cli/ember-cli/pull/9487.