### PR TITLE
Fix blueprint to routeless in-repo-engine

### DIFF
--- a/packages/ember-engines/blueprints/in-repo-engine/index.js
+++ b/packages/ember-engines/blueprints/in-repo-engine/index.js
@@ -73,12 +73,16 @@ module.exports = Object.assign({}, InRepoAddon, {
   afterInstall: function(options) {
     options.identifier = 'mount';
     InRepoAddon.afterInstall.call(this, options);
-    this.routeBlueprint.afterInstall.call(this, options);
+    if (options.type === 'routable') {
+      this.routeBlueprint.afterInstall.call(this, options);
+    }
   },
 
   afterUninstall: function(options) {
     options.identifier = 'mount';
-    this.routeBlueprint.afterUninstall.call(this, options);
+    if (options.type === 'routable') {
+      this.routeBlueprint.afterUninstall.call(this, options);
+    }
   },
 
   _generatePackageJson: function(/* options, isInstall*/) {


### PR DESCRIPTION
it fixes the #726 

The code added is skipping the blueprint to add `mount('foo')` into `router.js` for routeless engines.

cc: @dgeb @rwjblue 