### PR TITLE
[BUGFIX] Fallback to LinkTo behavior when outside an engine

### DIFF
--- a/packages/ember-engines/addon/components/link-to-external.js
+++ b/packages/ember-engines/addon/components/link-to-external.js
@@ -11,7 +11,7 @@ if (macroCondition(dependencySatisfies('ember-source', '> 3.24.0-alpha.1'))) {
       const owner = getOwner(this);
       
       if (!owner.mountPoint) {
-        return this._super(...arguments);
+        return super._namespaceRoute(...arguments);
       }
       
       const externalRoute = owner._getExternalRoute(targetRouteName);

--- a/packages/ember-engines/addon/components/link-to-external.js
+++ b/packages/ember-engines/addon/components/link-to-external.js
@@ -9,6 +9,11 @@ if (macroCondition(dependencySatisfies('ember-source', '> 3.24.0-alpha.1'))) {
   LinkToExternal = class LinkToExternal extends LinkComponent {
     _namespaceRoute(targetRouteName) {
       const owner = getOwner(this);
+      
+      if (!owner.mountPoint) {
+        return this._super(...arguments);
+      }
+      
       const externalRoute = owner._getExternalRoute(targetRouteName);
 
       return externalRoute;


### PR DESCRIPTION
Prior to Ember 3.24, LinkToExternal only modifier the `routeKey` when inside an engine; that is, when `owner.mountPoint` exists. With the new class that exists for 3.24+, this behavior regressed. Now, `_namespaceRoute` is overridden in all cases, which means that if `LinkToExternal` ever gets rendered outside of an engine, it will automatically fail since `owner._getExternalRoute` will not find the specified route.

Why this matters: Routing code that may be invoked by an engine does not necessarily live in the same addon as the engine itself. If we extract code that is intended to link to external routes, we still need to be able to test it in those addons, which don't have engines of their own. It's also possible to write reusable code that is designed to be invoked both in an engine and outside of one. The only way to do that is to use LinkToExternal, since the core LinkTo doesn't know that Engines exist. Prior to 3.24, this worked fine thanks to the `owner.mountPoint` check. By adding a similar check here, we ensure that `LinkToExternal` will make a best effort to find the correct route even if it's rendered outside an engine.