### PR TITLE
fix(build): #405 don't call `included()` twice

### DIFF
--- a/packages/ember-engines/lib/engine-addon.js
+++ b/packages/ember-engines/lib/engine-addon.js
@@ -605,9 +605,17 @@ function buildEngine(options) {
           };
         }
         originalIncluded.call(this, customHost);
+      } else {
+        // If an `originalIncluded` is present, we assume that it eventually 
+        // delegates to ember-cli's base implementation of `Addon#included()`,
+        // which already calls `included()` for every child addon instance.
+        // As such, we must only call `included()` manually, if there's no
+        // `originalIncluded`, which would have already done that.
+        // Otherwise, we would be calling `included()` twice, which leads to
+        // bugs.
+        // https://github.com/ember-engines/ember-engines/issues/405
+        this.nonDuplicatedAddonInvoke('included', [this]);
       }
-
-      this.nonDuplicatedAddonInvoke('included', [this]);
     };
 
     // The treeForEngine method constructs and returns a tree that represents


### PR DESCRIPTION
Fixes #405.

Fixes a bug where the `included()` hook of any addon listed in an engine's `dependencies` would be called twice.

See my comments in #405 for more details.

I have no clue, whether this is actually the correct fix, specifically with regards to `EMBER_ENGINES_ADDON_DEDUPE` introduced via #595. But it's working great for me.