### PR TITLE
Ember 4 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
           - ember-lts-3.20
           - ember-lts-3.24
           - ember-lts-3.28
+          - ember-lts-4.4
           - ember-release
           - ember-beta
           - ember-canary

--- a/packages/eager-blog/addon/templates/application.hbs
+++ b/packages/eager-blog/addon/templates/application.hbs
@@ -1,6 +1,6 @@
 <h3 class='title'>Eager engine</h3>
 
-{{#link-to "index" current-when="index post" class="current-when-test-link"}}All Posts{{/link-to}}|
-{{#link-to "post" 1}}Post 1{{/link-to}}
+<LinkTo @route="index" @current-when="index post" class="current-when-test-link">All Posts</LinkTo>|
+<LinkTo @route="post" @model=1>Post 1</LinkTo>
 
 {{outlet}}

--- a/packages/ember-blog/addon/templates/components/hello-name.hbs
+++ b/packages/ember-blog/addon/templates/components/hello-name.hbs
@@ -1,1 +1,1 @@
-Hello, {{name}}!
+Hello, {{this.name}}!

--- a/packages/ember-blog/addon/templates/index.hbs
+++ b/packages/ember-blog/addon/templates/index.hbs
@@ -1,5 +1,5 @@
 <ul>
-  <li>{{#link-to "post" 1 class="routable-post-1-link"}}Go to post #1{{/link-to}}</li>
-  <li>{{#link-to "post" 1 (query-params lang="Japanese") class="routable-post-1-link-jp"}}Go to post #1 with Japanese as language{{/link-to}}</li>
+  <li><LinkTo @route="post" @model=1 class="routable-post-1-link">Go to post #1</LinkTo></li>
   <li><button {{action "goToPostWithChinese"}} class="routable-post-1-link-ch">Go to post #1 with Chinese as language programmatically</button></li>
+  <li><LinkTo @route="post" @model=1 @query={{hash lang="Japanese"}} class="routable-post-1-link-jp"> Go to post #1 with Japanese as language</LinkTo></li>
 </ul>

--- a/packages/ember-blog/addon/templates/post.hbs
+++ b/packages/ember-blog/addon/templates/post.hbs
@@ -1,31 +1,30 @@
-<h3 class="post-title">{{model.title}}</h3>
+<h3 class="post-title">{{this.model.title}}</h3>
 
-<p class="author">{{model.user.name}}</p>
+<p class="author">{{this.model.user.name}}</p>
 
-<p class="language">{{lang}}</p>
+<p class="language">{{this.lang}}</p>
 
 <p>
-  {{#link-to this.commentsRoute 1 class="routable-post-comments-link"}}Comments{{/link-to}}
-  {{#link-to "post.likes" 1 class="routable-post-likes-link"}}Likes{{/link-to}}
-  {{#link-to "post.diggs" 1 class="routable-post-diggs-link"}}Diggs{{/link-to}}
+<LinkTo @route={{this.commentsRoute}} @model={{1}} class="routable-post-comments-link">Comments</LinkTo>
+<LinkTo @route="post.likes" @model={{1}} class="routable-post-likes-link">Likes</LinkTo>
+<LinkTo @route="post.diggs" @model={{1}} class="routable-post-diggs-link">Diggs</LinkTo>
 </p>
 
 {{outlet}}
 
-{{#link-to-external "home" class="routable-post-home-link"}}Go home{{/link-to-external}}
-{{#link-to "index" class="routable-post-blog-home-link"}}Go to blog home{{/link-to}}
-{{#link-to "application" class="routable-post-blog-home-link-app"}}Also goes to blog home{{/link-to}}
-
-{{#link-to (query-params lang="Japanese") class="routable-post-jp-link"}}Go to Japanese version{{/link-to}}
+<LinkToExternal @route="home" class="routable-post-home-link">Go home</LinkToExternal>
+<LinkTo @route="index" class="routable-post-blog-home-link">Go to blog home</LinkTo>
+<LinkTo @route="application" class="routable-post-blog-home-link-app">Also goes to blog home</LinkTo>
+<LinkTo @query={{hash lang="Japanese"}} class="routable-post-jp-link">Go to Japanese version</LinkTo>
 <button {{action "goToChineseVersion"}} class="routable-post-ch-link">Go to Chinese version</button>
-<button {{action "transitionToHome"}} class="routable-post-transition-to-home-button {{if transitionedToExternal 'transitioned-to-external'}}">
+<button {{action "transitionToHome"}} class="routable-post-transition-to-home-button {{if this.transitionedToExternal 'transitioned-to-external'}}">
     Go home programmatically
 </button>
 
-<button {{action "transitionToHomeFromController"}} class="routable-post-transition-to-route-home-button {{if transitionedToExternalRoute 'transitioned-to-external-route'}}">
+<button {{action "transitionToHomeFromController"}} class="routable-post-transition-to-route-home-button {{if this.transitionedToExternalRoute 'transitioned-to-external-route'}}">
     Go home by controller
 </button>
 
-<button {{action "replaceWithHome"}} class="routable-post-replace-with-home-button {{if replacedWithExternal 'replaced-with-external'}}">
+<button {{action "replaceWithHome"}} class="routable-post-replace-with-home-button {{if this.replacedWithExternal 'replaced-with-external'}}">
     Also goes home programmatically
 </button>

--- a/packages/ember-blog/addon/templates/post/comments.hbs
+++ b/packages/ember-blog/addon/templates/post/comments.hbs
@@ -1,5 +1,5 @@
-<h4 class="comments">Comments for {{model.title}}</h4>
+<h4 class="comments">Comments for {{this.model.title}}</h4>
 
-{{#link-to "post" class="back-to-post-link"}}
+<LinkTo @route="post" class="back-to-post-link">
   Back to Post
-{{/link-to}}
+</LinkTo>

--- a/packages/ember-blog/addon/templates/post/error.hbs
+++ b/packages/ember-blog/addon/templates/post/error.hbs
@@ -1,1 +1,1 @@
-<h2 class="error-message">Error: {{model.message}}</h2>
+<h2 class="error-message">Error: {{this.model.message}}</h2>

--- a/packages/ember-chat/addon/templates/application.hbs
+++ b/packages/ember-chat/addon/templates/application.hbs
@@ -1,7 +1,7 @@
 <div class="engine">
-  Engine: {{name}}
+  Engine: {{this.name}}
 
-  <div class="hello">{{hello-world name=name}}</div>
+  <div class="hello">{{hello-world name=this.name}}</div>
 
-  <div class="hola">{{spanish-greeting name=name}}</div>
+  <div class="hola">{{spanish-greeting name=this.name}}</div>
 </div>

--- a/packages/ember-chat/addon/templates/components/hello-world.hbs
+++ b/packages/ember-chat/addon/templates/components/hello-world.hbs
@@ -1,3 +1,3 @@
-<span class="greeting">Hello</span> from {{name}}!
+<span class="greeting">Hello</span> from {{this.name}}!
 <button class="clicker" {{action "click"}}>Clicker</button>
-<span class="click-count">{{clickCount}}</span>
+<span class="click-count">{{this.clickCount}}</span>

--- a/packages/ember-engines/addon/-private/engine-ext.js
+++ b/packages/ember-engines/addon/-private/engine-ext.js
@@ -9,7 +9,7 @@ Engine.reopen({
     let registry = this._super(...arguments);
 
     if (!(this instanceof Application)) {
-      if (macroCondition(!dependencySatisfies('ember-source', '>= 3.24.1'))) {
+      if (macroCondition(!dependencySatisfies('ember-source', '>= 3.24.1 || >=4.x'))) {
         const EngineScopedLinkComponent = importSync('ember-engines/components/link-to-component').default;
         registry.register('component:link-to', EngineScopedLinkComponent);
       }

--- a/packages/ember-engines/addon/components/link-to-component.js
+++ b/packages/ember-engines/addon/components/link-to-component.js
@@ -1,11 +1,19 @@
-import LinkComponent from '@ember/routing/link-component';
+import RoutingLinkComponent from '@ember/routing/link-component';
 import { getOwner } from '@ember/application';
 import { computed, get, set } from '@ember/object';
 import { typeOf } from '@ember/utils';
 import { assert, deprecate } from '@ember/debug';
-import { macroCondition, dependencySatisfies } from '@embroider/macros';
+import { macroCondition, dependencySatisfies, importSync } from '@embroider/macros';
 
 let LinkTo;
+let LinkComponent;
+
+if (macroCondition(dependencySatisfies('@ember/legacy-built-in-components', '*'))) {
+  let { LinkComponent: LegacyLinkComponent } = importSync('@ember/legacy-built-in-components');
+  LinkComponent = LegacyLinkComponent;
+} else {
+  LinkComponent = RoutingLinkComponent;
+}
 
 if (macroCondition(dependencySatisfies('ember-source', '>= 3.24.1'))) {
   deprecate(
@@ -22,24 +30,6 @@ if (macroCondition(dependencySatisfies('ember-source', '>= 3.24.1'))) {
   );
 
   LinkTo = LinkComponent;
-} else if (macroCondition(dependencySatisfies('ember-source', '> 3.24.0-alpha.1'))) {
-  LinkTo = class EnginesLinkComponent extends LinkComponent {
-    // temporarily work around an issue in Ember 3.24.0 where when a route name is
-    // **not** defined (e.g. a QP only transition) we re-wrap the current name (essentially
-    // double namespacing it)
-    //
-    // can be removed once https://github.com/emberjs/ember.js/pull/19337 is landed and released as 3.24.1
-    @computed('route', '_currentRouterState')
-    get _route() {
-      let { route } = this;
-
-      if (route.toString() === 'UNDEFINED') {
-        return this._currentRoute;
-      } else {
-        return this._namespaceRoute(route);
-      }
-    }
-  };
 } else {
   LinkTo = LinkComponent.extend({
     _route: computed('route', '_mountPoint', '_currentRouteState', function () {

--- a/packages/ember-engines/addon/components/link-to-component.js
+++ b/packages/ember-engines/addon/components/link-to-component.js
@@ -17,7 +17,7 @@ if (macroCondition(dependencySatisfies('@ember/legacy-built-in-components', '*')
   LinkComponent = RoutingLinkComponent;
 }
 
-if (macroCondition(dependencySatisfies('ember-source', '>= 3.24.1'))) {
+if (macroCondition(dependencySatisfies('ember-source', '>= 3.24.1 || >=4.x'))) {
   deprecate(
     `Importing from 'ember-engines/components/link-to-component' is deprecated, please use '@ember/routing/link-component' directly`,
     false,

--- a/packages/ember-engines/addon/components/link-to-component.js
+++ b/packages/ember-engines/addon/components/link-to-component.js
@@ -1,3 +1,5 @@
+// this file is only used when ember is older than 3.24
+// ember-engines/addon/-private/engine-ext.js
 import RoutingLinkComponent from '@ember/routing/link-component';
 import { getOwner } from '@ember/application';
 import { computed, get, set } from '@ember/object';

--- a/packages/ember-engines/addon/components/link-to-external.js
+++ b/packages/ember-engines/addon/components/link-to-external.js
@@ -31,42 +31,6 @@ if (macroCondition(dependencySatisfies('ember-source', '> 3.24.0-alpha.1'))) {
     // checks to make sure LinkTo is not being used inside a routeless engine
     // See this PR here for more details: https://github.com/emberjs/ember.js/pull/19477
     assertLinkToOrigin() {}
-
-    _invoke() {
-      // This patches @ember/legacy-built-in-components
-      // @ember/legacy-built-in-components don't call the generated transition resulting in nothing.
-      // Likely this is a bug caused because the addon doesn't have acces to flaggedInstrument function
-      // imported from glimmer which is triggering the transition
-      // https://github.com/emberjs/ember-legacy-built-in-components/blob/v0.4.0/addon/components/link-to.ts#L804
-      // https://github.com/emberjs/ember.js/blob/v3.28.8/packages/%40ember/-internals/glimmer/lib/components/-link-to.ts#L767
-      if (macroCondition(dependencySatisfies('@ember/legacy-built-in-components', '*'))) {
-        const result = super._invoke(...arguments);
-
-        let {
-          _route: routeName,
-          _models: models,
-          _query: queryParams,
-          replace: shouldReplace,
-        } = this;
-
-        let payload = {
-          queryParams,
-          routeName,
-        };
-
-        this._generateTransition(
-          payload,
-          routeName,
-          models,
-          queryParams,
-          shouldReplace
-        )();
-
-        return result;
-      }
-
-      return super._invoke(...arguments);
-    }
   };
 } else {
   LinkToExternal = LinkComponent.extend({

--- a/packages/ember-engines/addon/components/link-to-external.js
+++ b/packages/ember-engines/addon/components/link-to-external.js
@@ -1,15 +1,23 @@
-import LinkComponent from '@ember/routing/link-component';
+import { LinkTo as RoutingLinkComponent } from '@ember/routing';
 import { getOwner } from '@ember/application';
 import { set, get } from '@ember/object';
-import { macroCondition, dependencySatisfies } from '@embroider/macros';
+import { macroCondition, dependencySatisfies, importSync } from '@embroider/macros';
 
 let LinkToExternal;
+let LinkComponent;
+
+if (macroCondition(dependencySatisfies('@ember/legacy-built-in-components', '*'))) {
+  let { LinkComponent: LegacyLinkComponent } = importSync('@ember/legacy-built-in-components');
+  LinkComponent = LegacyLinkComponent;
+} else {
+  LinkComponent = RoutingLinkComponent;
+}
 
 if (macroCondition(dependencySatisfies('ember-source', '> 3.24.0-alpha.1'))) {
   LinkToExternal = class LinkToExternal extends LinkComponent {
     _namespaceRoute(targetRouteName) {
       const owner = getOwner(this);
-      
+     
       if (!owner.mountPoint) {
         return super._namespaceRoute(...arguments);
       }
@@ -23,6 +31,42 @@ if (macroCondition(dependencySatisfies('ember-source', '> 3.24.0-alpha.1'))) {
     // checks to make sure LinkTo is not being used inside a routeless engine
     // See this PR here for more details: https://github.com/emberjs/ember.js/pull/19477
     assertLinkToOrigin() {}
+
+    _invoke() {
+      // This patches @ember/legacy-built-in-components
+      // @ember/legacy-built-in-components don't call the generated transition resulting in nothing.
+      // Likely this is a bug caused because the addon doesn't have acces to flaggedInstrument function
+      // imported from glimmer which is triggering the transition
+      // https://github.com/emberjs/ember-legacy-built-in-components/blob/v0.4.0/addon/components/link-to.ts#L804
+      // https://github.com/emberjs/ember.js/blob/v3.28.8/packages/%40ember/-internals/glimmer/lib/components/-link-to.ts#L767
+      if (macroCondition(dependencySatisfies('@ember/legacy-built-in-components', '*'))) {
+        const result = super._invoke(...arguments);
+
+        let {
+          _route: routeName,
+          _models: models,
+          _query: queryParams,
+          replace: shouldReplace,
+        } = this;
+
+        let payload = {
+          queryParams,
+          routeName,
+        };
+
+        this._generateTransition(
+          payload,
+          routeName,
+          models,
+          queryParams,
+          shouldReplace
+        )();
+
+        return result;
+      }
+
+      return super._invoke(...arguments);
+    }
   };
 } else {
   LinkToExternal = LinkComponent.extend({

--- a/packages/ember-engines/addon/components/link-to-external.js
+++ b/packages/ember-engines/addon/components/link-to-external.js
@@ -13,7 +13,7 @@ if (macroCondition(dependencySatisfies('@ember/legacy-built-in-components', '*')
   LinkComponent = RoutingLinkComponent;
 }
 
-if (macroCondition(dependencySatisfies('ember-source', '> 3.24.0-alpha.1'))) {
+if (macroCondition(dependencySatisfies('ember-source', '>=3.24.1 || >=4.x'))) {
   LinkToExternal = class LinkToExternal extends LinkComponent {
     _namespaceRoute(targetRouteName) {
       const owner = getOwner(this);

--- a/packages/ember-engines/config/ember-try.js
+++ b/packages/ember-engines/config/ember-try.js
@@ -26,7 +26,7 @@ module.exports = async function() {
         name: 'ember-lts-3.20',
         npm: {
           devDependencies: {
-            'ember-source': '~3.20.0'
+            'ember-source': '~3.20.0',
           }
         }
       },
@@ -34,7 +34,7 @@ module.exports = async function() {
         name: 'ember-lts-3.24',
         npm: {
           devDependencies: {
-            'ember-source': '~3.24.0'
+            'ember-source': '~3.24.0',
           }
         }
       },
@@ -42,7 +42,7 @@ module.exports = async function() {
         name: 'ember-lts-3.28',
         npm: {
           devDependencies: {
-            'ember-source': '~3.28.0'
+            'ember-source': '~3.28.0',
           }
         }
       },
@@ -50,7 +50,10 @@ module.exports = async function() {
         name: "ember-release",
         npm: {
           devDependencies: {
-            "ember-source": await getChannelURL("release")
+            "ember-source": await getChannelURL("release"),
+            "ember-cli": "~3.28.0",
+            "ember-cli-app-version": "^5.0.0",
+            '@ember/legacy-built-in-components': "~0.4.0",
           }
         }
       },
@@ -58,7 +61,10 @@ module.exports = async function() {
         name: "ember-beta",
         npm: {
           devDependencies: {
-            "ember-source": await getChannelURL("beta")
+            "ember-source": await getChannelURL("beta"),
+            "ember-cli": "~3.28.0",
+            "ember-cli-app-version": "^5.0.0",
+            '@ember/legacy-built-in-components': "~0.4.0",
           }
         }
       },
@@ -66,7 +72,10 @@ module.exports = async function() {
         name: "ember-canary",
         npm: {
           devDependencies: {
-            "ember-source": await getChannelURL("canary")
+            "ember-source": await getChannelURL("canary"),
+            "ember-cli": "~3.28.0",
+            "ember-cli-app-version": "^5.0.0",
+            '@ember/legacy-built-in-components': "~0.4.0",
           }
         }
       },

--- a/packages/ember-engines/config/ember-try.js
+++ b/packages/ember-engines/config/ember-try.js
@@ -47,6 +47,17 @@ module.exports = async function() {
         }
       },
       {
+        name: "ember-lts-4.4",
+        npm: {
+          devDependencies: {
+            "ember-source": "^4.4.0-alpha.1",
+            "ember-cli": "~3.28.0",
+            "ember-cli-app-version": "^5.0.0",
+            '@ember/legacy-built-in-components': "~0.4.0",
+          }
+        }
+      },
+      {
         name: "ember-release",
         npm: {
           devDependencies: {

--- a/packages/ember-engines/package.json
+++ b/packages/ember-engines/package.json
@@ -109,7 +109,7 @@
     "lodash": "^4.17.11"
   },
   "peerDependencies": {
-    "ember-source": "^3.12"
+    "ember-source": "^3.12 || 4"
   },
   "engines": {
     "node": "10.* || >= 12"

--- a/packages/ember-engines/package.json
+++ b/packages/ember-engines/package.json
@@ -109,7 +109,8 @@
     "lodash": "^4.17.11"
   },
   "peerDependencies": {
-    "ember-source": "^3.12 || 4"
+    "ember-source": "^3.12 || 4",
+    "@ember/legacy-built-in-components": "*"
   },
   "engines": {
     "node": "10.* || >= 12"

--- a/packages/ember-engines/tests/integration/component-with-link-to-external-test.js
+++ b/packages/ember-engines/tests/integration/component-with-link-to-external-test.js
@@ -29,7 +29,7 @@ module("Integration | Component | component-with-link-to-external", function(
 
     await render(hbs`
     {{#test-component}}
-      {{#link-to "view"}}Link To{{/link-to}}
+      {{#link-to route="view"}}Link To{{/link-to}}
       {{#link-to-external "home"}}Link To External{{/link-to-external}}
     {{/test-component}}
   `);

--- a/packages/ember-engines/tests/unit/engine-instance-test.js
+++ b/packages/ember-engines/tests/unit/engine-instance-test.js
@@ -13,12 +13,12 @@ module('Unit | EngineInstance', function(hooks) {
   hooks.beforeEach(function() {
     EnginesInitializer.initialize();
 
-    App = Application.extend({
-      Resolver,
-      modulePrefix: config.modulePrefix,
-      router: null,
-      autoboot: false
-    });
+    App = class EmberApp extends Application {
+      Resolver = Resolver
+      modulePrefix = config.modulePrefix
+      router = null
+      autoboot = false
+    }
 
     run(function() {
       app = App.create();
@@ -40,10 +40,11 @@ module('Unit | EngineInstance', function(hooks) {
   ) {
     assert.expect(1);
 
-    let BlogEngine = Engine.extend({
-      router: null,
-      dependencies: Object.freeze({}),
-    });
+    class BlogEngine extends Engine {
+      Resolver = Resolver;
+      router = null
+      dependencies = Object.freeze({})
+    }
 
     app.engines = undefined;
 
@@ -64,7 +65,10 @@ module('Unit | EngineInstance', function(hooks) {
   ) {
     assert.expect(1);
 
-    let BlogEngine = Engine.extend({ router: null });
+    class BlogEngine extends Engine {
+      Resolver = Resolver;
+      router = null
+    }
 
     app.register('engine:blog', BlogEngine);
 
@@ -83,12 +87,13 @@ module('Unit | EngineInstance', function(hooks) {
   ) {
     assert.expect(2);
 
-    let BlogEngine = Engine.extend({
-      router: null,
-      dependencies: Object.freeze({
+    class BlogEngine extends Engine {
+      Resolver = Resolver
+      router = null
+      dependencies = Object.freeze({
         services: ['store'],
-      }),
-    });
+      })
+    }
 
     app.engines = {
       blog: {
@@ -121,12 +126,13 @@ module('Unit | EngineInstance', function(hooks) {
   ) {
     assert.expect(2);
 
-    let BlogEngine = Engine.extend({
-      router: null,
-      dependencies: Object.freeze({
+    class BlogEngine extends Engine {
+      Resolver = Resolver
+      router = null
+      dependencies = Object.freeze({
         services: ['router'],
-      }),
-    });
+      })
+    }
 
     app.engines = {
       blog: {
@@ -155,14 +161,15 @@ module('Unit | EngineInstance', function(hooks) {
   ) {
     assert.expect(2);
 
-    let BlogEngine = Engine.extend({
-      router: null,
-      dependencies: Object.freeze({
+    class BlogEngine extends Engine {
+      Resolver = Resolver
+      router = null
+      dependencies = Object.freeze({
         services: [
           'data-store', // NOTE: Blog engine uses alias to 'store'
-        ],
-      }),
-    });
+        ]
+      })
+    }
 
     app.engines = {
       blog: {
@@ -195,19 +202,20 @@ module('Unit | EngineInstance', function(hooks) {
   test('it deprecates support for camelized engine names', async function(assert) {
     assert.expect(6);
 
-    let NormalBlogEngine = Engine.extend({
-      router: null,
-      dependencies: Object.freeze({
+    class NormalBlogEngine extends Engine {
+      Resolver = Resolver
+      router = null
+      dependencies = Object.freeze({
         services: ['store'],
-      }),
-    });
-
-    let SuperBlogEngine = Engine.extend({
-      router: null,
-      dependencies: Object.freeze({
+      })
+    }
+    class SuperBlogEngine extends Engine {
+      Resolver = Resolver
+      router = null
+      dependencies = Object.freeze({
         services: ['store'],
-      }),
-    });
+      })
+    }
 
     app.engines = {
       'normal-blog': {

--- a/packages/ember-engines/tests/unit/initializers/engines-test.js
+++ b/packages/ember-engines/tests/unit/initializers/engines-test.js
@@ -2,14 +2,19 @@ import Application from '@ember/application';
 import { run } from '@ember/runloop';
 import EnginesInitializer from '../../../initializers/engines';
 import { module, test } from 'qunit';
+import Resolver from '../../../resolver';
+import config from '../../../config/environment';
 
+class App extends Application {
+  Resolver = Resolver
+  modulePrefix = config.modulePrefix
+}
 let application;
 
 module('Unit | Initializer | engines', function(hooks) {
   hooks.beforeEach(function() {
     run(() => {
-      application = Application.create();
-      application.deferReadiness();
+      application = App.create();
     });
   });
 


### PR DESCRIPTION
Built on top of https://github.com/ember-engines/ember-engines/pull/797

- Refactors link-to to LinkTo
- Requires @ember/legacy-built-in-components for ember > 3.24
- Refactors templates to use component/controller properties with `this`