### PR TITLE
Breaking test: resetNamespace _within_ an engines routes is broken

### DIFF
--- a/packages/ember-blog/addon/routes.js
+++ b/packages/ember-blog/addon/routes.js
@@ -13,5 +13,8 @@ export default buildRoutes(function() {
 
     // The diggs route throws an error to test error states
     this.route('diggs');
+
+    this.route('post-reset-namespace', { resetNamespace: true }, function() {
+    });
   });
 });

--- a/packages/ember-blog/addon/templates/post-reset-namespace/index.hbs
+++ b/packages/ember-blog/addon/templates/post-reset-namespace/index.hbs
@@ -1,0 +1,1 @@
+<h2>post-reset-namespace</h2>

--- a/packages/ember-blog/addon/templates/post.hbs
+++ b/packages/ember-blog/addon/templates/post.hbs
@@ -8,6 +8,7 @@
   {{#link-to this.commentsRoute 1 class="routable-post-comments-link"}}Comments{{/link-to}}
   {{#link-to "post.likes" 1 class="routable-post-likes-link"}}Likes{{/link-to}}
   {{#link-to "post.diggs" 1 class="routable-post-diggs-link"}}Diggs{{/link-to}}
+  {{#link-to "post-reset-namespace" 1 class="routable-post-reset-namespace-link"}}post-reset-namespace{{/link-to}}
 </p>
 
 {{outlet}}


### PR DESCRIPTION
Using `resetNamespace:true` when _mounting_ an engine works, but if the engine itself has routes with `resetNamespace:true`, those routes get entirely stripped of their engine mount prefix, causing errors within link-to and any other place that needs to resolve the route name.

In this PR, `post-reset-namespace` should have a route name of 'blog.post-reset-namespace` but it gets registered (potentially multiple times if there are multiple mounts) as just `post-reset-namespace`, causing errors like:

> Error: Assertion Failed: You attempted to generate a link for the "post-reset-namespace" route, but did not pass the models required for generating its dynamic segments. There is no route named blog.post-reset-namespace

I suspect the fix might need to be in Ember proper, but this seemed like the right place to share.