### PR TITLE
Add exclude list to addon dedupe logic

### DIFF
--- a/packages/ember-engines/lib/utils/deeply-non-duplicated-addon.js
+++ b/packages/ember-engines/lib/utils/deeply-non-duplicated-addon.js
@@ -1,5 +1,10 @@
 'use strict';
 
+// Array of addon names that should not be deduped.
+const ADDONS_TO_EXCLUDE_FROM_DEDUPE = [
+  'ember-cli-babel',
+];
+
 /**
  * Deduplicate one addon's children addons recursively from hostAddons.
  *
@@ -20,6 +25,10 @@ module.exports = function deeplyNonDuplicatedAddon(hostAddons, dedupedAddon, tre
       return true;
     }
 
+    if (ADDONS_TO_EXCLUDE_FROM_DEDUPE.includes(addon.name)) {
+      return true;
+    }
+    
     if (addon.addons.length > 0) {
       addon._orginalAddons = addon.addons;
       deeplyNonDuplicatedAddon(hostAddons, addon, treeName);


### PR DESCRIPTION
The following is cobbled together from a JIRA ticket, so it is a bit fragmented.

## Summary
When addons try to access `ember-cli-babel` during the build stage, `EMBER_ENGINES_ADDON_DEDUPE=true` can cause `this.addons` to be empty. Instead of requiring addons to do something like `this.addons.find(...) || this.project.addons.find(...)`, we should exclude `ember-cli-babel` from dedupe logic so it's available.


Related code in ember-engines:
https://github.com/ember-engines/ember-engines/blob/e24764341c0246a1dfa3875e7241482db1a61c26/packages/ember-engines/lib/engine-addon.js#L845

https://github.com/ember-engines/ember-engines/blob/e24764341c0246a1dfa3875e7241482db1a61c26/packages/ember-engines/lib/engine-addon.js#L397-L417

cc: @rwjblue @brendenpalmer 