### PR TITLE
Refactor LinkToExternal to use LinkTo directly

### DIFF
--- a/packages/ember-engines/addon/components/link-to-component.js
+++ b/packages/ember-engines/addon/components/link-to-component.js
@@ -5,17 +5,9 @@ import { getOwner } from '@ember/application';
 import { computed, get, set } from '@ember/object';
 import { typeOf } from '@ember/utils';
 import { assert, deprecate } from '@ember/debug';
-import { macroCondition, dependencySatisfies, importSync } from '@embroider/macros';
+import { macroCondition, dependencySatisfies } from '@embroider/macros';
 
 let LinkTo;
-let LinkComponent;
-
-if (macroCondition(dependencySatisfies('@ember/legacy-built-in-components', '*'))) {
-  let { LinkComponent: LegacyLinkComponent } = importSync('@ember/legacy-built-in-components');
-  LinkComponent = LegacyLinkComponent;
-} else {
-  LinkComponent = RoutingLinkComponent;
-}
 
 if (macroCondition(dependencySatisfies('ember-source', '>= 3.24.1 || >=4.x'))) {
   deprecate(
@@ -31,9 +23,9 @@ if (macroCondition(dependencySatisfies('ember-source', '>= 3.24.1 || >=4.x'))) {
     }
   );
 
-  LinkTo = LinkComponent;
+  LinkTo = RoutingLinkComponent;
 } else {
-  LinkTo = LinkComponent.extend({
+  LinkTo = RoutingLinkComponent.extend({
     _route: computed('route', '_mountPoint', '_currentRouteState', function () {
       let routeName = this._super(...arguments);
       let mountPoint = get(this, '_mountPoint');

--- a/packages/ember-engines/addon/components/link-to-external.js
+++ b/packages/ember-engines/addon/components/link-to-external.js
@@ -1,5 +1,3 @@
-import Component from '@glimmer/component';
-import { setComponentTemplate } from '@glimmer/manager';
 import { LinkTo as RoutingLinkComponent } from '@ember/routing';
 import { getOwner } from '@ember/application';
 import { set, get } from '@ember/object';
@@ -16,13 +14,16 @@ if (macroCondition(dependencySatisfies('@ember/legacy-built-in-components', '*')
   LinkComponent = RoutingLinkComponent;
 }
 if (macroCondition(dependencySatisfies('ember-source', '>= v4.0.0-beta.9'))) {
+  const { default: Component } = importSync('@glimmer/component');
+  const { setComponentTemplate } = importSync('@glimmer/manager');
+
   LinkToExternal = class LinkToExternal extends Component {
     get route () {
       return getOwner(this)._getExternalRoute(this.args.route);
     }
   };
-  setComponentTemplate(template, LinkToExternal);
 
+  setComponentTemplate(template, LinkToExternal);
 } else if (macroCondition(dependencySatisfies('ember-source', '>=3.24.1 || >=4.x'))) {
   LinkToExternal = class LinkToExternal extends LinkComponent {
     _namespaceRoute(targetRouteName) {

--- a/packages/ember-engines/addon/components/link-to-external.js
+++ b/packages/ember-engines/addon/components/link-to-external.js
@@ -1,7 +1,10 @@
+import Component from '@glimmer/component';
+import { setComponentTemplate } from '@glimmer/manager';
 import { LinkTo as RoutingLinkComponent } from '@ember/routing';
 import { getOwner } from '@ember/application';
 import { set, get } from '@ember/object';
 import { macroCondition, dependencySatisfies, importSync } from '@embroider/macros';
+import template from '../templates/link-to-external-template';
 
 let LinkToExternal;
 let LinkComponent;
@@ -12,8 +15,15 @@ if (macroCondition(dependencySatisfies('@ember/legacy-built-in-components', '*')
 } else {
   LinkComponent = RoutingLinkComponent;
 }
+if (macroCondition(dependencySatisfies('ember-source', '>= v4.0.0-beta.9'))) {
+  LinkToExternal = class LinkToExternal extends Component {
+    get route () {
+      return getOwner(this)._getExternalRoute(this.args.route);
+    }
+  };
+  setComponentTemplate(template, LinkToExternal);
 
-if (macroCondition(dependencySatisfies('ember-source', '>=3.24.1 || >=4.x'))) {
+} else if (macroCondition(dependencySatisfies('ember-source', '>=3.24.1 || >=4.x'))) {
   LinkToExternal = class LinkToExternal extends LinkComponent {
     _namespaceRoute(targetRouteName) {
       const owner = getOwner(this);

--- a/packages/ember-engines/addon/components/link-to-external.js
+++ b/packages/ember-engines/addon/components/link-to-external.js
@@ -5,14 +5,7 @@ import { macroCondition, dependencySatisfies, importSync } from '@embroider/macr
 import template from '../templates/link-to-external-template';
 
 let LinkToExternal;
-let LinkComponent;
 
-if (macroCondition(dependencySatisfies('@ember/legacy-built-in-components', '*'))) {
-  let { LinkComponent: LegacyLinkComponent } = importSync('@ember/legacy-built-in-components');
-  LinkComponent = LegacyLinkComponent;
-} else {
-  LinkComponent = RoutingLinkComponent;
-}
 if (macroCondition(dependencySatisfies('ember-source', '>= v4.0.0-beta.9'))) {
   const { default: Component } = importSync('@glimmer/component');
   const { setComponentTemplate } = importSync('@glimmer/manager');
@@ -25,7 +18,7 @@ if (macroCondition(dependencySatisfies('ember-source', '>= v4.0.0-beta.9'))) {
 
   setComponentTemplate(template, LinkToExternal);
 } else if (macroCondition(dependencySatisfies('ember-source', '>=3.24.1 || >=4.x'))) {
-  LinkToExternal = class LinkToExternal extends LinkComponent {
+  LinkToExternal = class LinkToExternal extends RoutingLinkComponent {
     _namespaceRoute(targetRouteName) {
       const owner = getOwner(this);
      
@@ -44,7 +37,7 @@ if (macroCondition(dependencySatisfies('ember-source', '>= v4.0.0-beta.9'))) {
     assertLinkToOrigin() {}
   };
 } else {
-  LinkToExternal = LinkComponent.extend({
+  LinkToExternal = RoutingLinkComponent.extend({
     didReceiveAttrs() {
       this._super(...arguments);
 

--- a/packages/ember-engines/addon/templates/link-to-external-template.hbs
+++ b/packages/ember-engines/addon/templates/link-to-external-template.hbs
@@ -1,0 +1,2 @@
+<LinkTo @route={{this.route}} @isExternal={{true}} ...attributes>{{yield}}</LinkTo> 
+

--- a/packages/ember-engines/config/ember-try.js
+++ b/packages/ember-engines/config/ember-try.js
@@ -53,7 +53,6 @@ module.exports = async function() {
             "ember-source": "^4.4.0-alpha.1",
             "ember-cli": "~3.28.0",
             "ember-cli-app-version": "^5.0.0",
-            '@ember/legacy-built-in-components': "~0.4.0",
           }
         }
       },
@@ -64,7 +63,6 @@ module.exports = async function() {
             "ember-source": await getChannelURL("release"),
             "ember-cli": "~3.28.0",
             "ember-cli-app-version": "^5.0.0",
-            '@ember/legacy-built-in-components': "~0.4.0",
           }
         }
       },
@@ -75,7 +73,6 @@ module.exports = async function() {
             "ember-source": await getChannelURL("beta"),
             "ember-cli": "~3.28.0",
             "ember-cli-app-version": "^5.0.0",
-            '@ember/legacy-built-in-components': "~0.4.0",
           }
         }
       },
@@ -86,7 +83,6 @@ module.exports = async function() {
             "ember-source": await getChannelURL("canary"),
             "ember-cli": "~3.28.0",
             "ember-cli-app-version": "^5.0.0",
-            '@ember/legacy-built-in-components': "~0.4.0",
           }
         }
       },

--- a/packages/ember-engines/package.json
+++ b/packages/ember-engines/package.json
@@ -50,6 +50,7 @@
     "ember-chat": "0.8.23",
     "ember-cli": "~3.17.0",
     "ember-cli-addon-tests": "^0.11.1",
+    "ember-cli-app-version": "^3.2.0",
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",

--- a/packages/ember-engines/package.json
+++ b/packages/ember-engines/package.json
@@ -109,8 +109,7 @@
     "lodash": "^4.17.11"
   },
   "peerDependencies": {
-    "ember-source": "^3.12 || 4",
-    "@ember/legacy-built-in-components": "*"
+    "ember-source": "^3.12 || 4"
   },
   "engines": {
     "node": "10.* || >= 12"

--- a/packages/ember-engines/package.json
+++ b/packages/ember-engines/package.json
@@ -50,9 +50,7 @@
     "ember-chat": "0.8.23",
     "ember-cli": "~3.17.0",
     "ember-cli-addon-tests": "^0.11.1",
-    "ember-cli-app-version": "^3.2.0",
     "ember-cli-dependency-checker": "^3.2.0",
-    "ember-cli-htmlbars": "^5.3.2",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-uglify": "^3.0.0",
@@ -106,6 +104,7 @@
     "ember-cli-preprocess-registry": "^3.3.0",
     "ember-cli-string-utils": "^1.1.0",
     "ember-cli-version-checker": "^5.1.2",
+    "ember-cli-htmlbars": "^5.3.2",
     "lodash": "^4.17.11"
   },
   "peerDependencies": {

--- a/packages/ember-engines/tests/integration/component-with-link-to-external-test.js
+++ b/packages/ember-engines/tests/integration/component-with-link-to-external-test.js
@@ -24,19 +24,6 @@ module("Integration | Component | component-with-link-to-external", function(
     this.owner._externalRoutes['home'] = 'application';
   });
 
-  test("component renders with link-to-external [curly braces]", async function(assert) {
-    assert.expect(1);
-
-    await render(hbs`
-    {{#test-component}}
-      {{#link-to route="view"}}Link To{{/link-to}}
-      {{#link-to-external "home"}}Link To External{{/link-to-external}}
-    {{/test-component}}
-  `);
-
-    assert.ok(this.element);
-  });
-
   test("component renders with link-to-external [angle brackets]", async function(assert) {
     assert.expect(1);
 

--- a/packages/ember-engines/tests/unit/components/link-to-external-test.js
+++ b/packages/ember-engines/tests/unit/components/link-to-external-test.js
@@ -11,11 +11,6 @@ module('Integration | Component | pretty color', function(hooks) {
     this.owner._externalRoutes['home'] = 'application';
   });
 
-  test('it renders properly [curly braces]', async function(assert) {
-    await render(hbs`{{link-to-external 'home' 'home'}}`);
-    assert.equal(this.element.querySelector('a').textContent, 'home');
-  });
-
   test('it renders properly [angle brackets]', async function(assert) {
     await render(hbs`<LinkToExternal @route='home'>home</LinkToExternal>`);
     assert.equal(this.element.querySelector('a').textContent, 'home');


### PR DESCRIPTION
blocked by https://github.com/emberjs/ember.js/pull/20151

- removes dependency on @ember/legacy-built-in-components introduced here https://github.com/ember-engines/ember-engines/pull/798
- Removes tests invoking link-to-external with positional args
  - this is possibly a breaking change, although in Ember v4 LinkTo already doesn't handle that.
