### PR TITLE
Add deprecation warning to `engineResolverFor`

### DIFF
--- a/packages/ember-engines/addon-test-support/engine-resolver-for.js
+++ b/packages/ember-engines/addon-test-support/engine-resolver-for.js
@@ -1,5 +1,6 @@
 /* global require */
 import EmberResolver from 'ember-resolver';
+import { deprecate } from '@ember/debug';
 
 /**
  * Gets the resolver class used by an Engine and creates an instance to be used
@@ -29,6 +30,18 @@ export default function engineResolverFor(
   modulePrefix = engineName,
   podModulePrefix = undefined
 ) {
+  deprecate(
+    "Use of `engineResolverFor` has been deprecated. Instead use `setupEngine(hooks, 'engine-name')` imported from `ember-engines/test-support` to load and setup the engine you need",
+    false,
+    {
+      id: 'ember-engines.addon-test-support.engine-resolver-for',
+      for: 'ember-engines',
+      until: '1.0.0',
+      since: {
+        enabled: '0.8.23',
+        available: '0.8.23',
+      }
+    });
   let Resolver;
 
   if (require.has(`${engineName}/resolver`)) {

--- a/packages/ember-engines/addon-test-support/engine-resolver-for.js
+++ b/packages/ember-engines/addon-test-support/engine-resolver-for.js
@@ -38,8 +38,8 @@ export default function engineResolverFor(
       for: 'ember-engines',
       until: '1.0.0',
       since: {
-        enabled: '0.8.23',
-        available: '0.8.23',
+        enabled: '0.8.24',
+        available: '0.8.24',
       }
     });
 

--- a/packages/ember-engines/addon-test-support/engine-resolver-for.js
+++ b/packages/ember-engines/addon-test-support/engine-resolver-for.js
@@ -31,7 +31,7 @@ export default function engineResolverFor(
   podModulePrefix = undefined
 ) {
   deprecate(
-    "Use of `engineResolverFor` has been deprecated. Instead use `setupEngine(hooks, 'engine-name')` imported from `ember-engines/test-support` to load and setup the engine you need",
+    "Use of `engineResolverFor` has been deprecated. Instead use `setupEngine(hooks, 'engine-name')` imported from `ember-engines/test-support` to load the engine you need.",
     false,
     {
       id: 'ember-engines.addon-test-support.engine-resolver-for',
@@ -42,6 +42,7 @@ export default function engineResolverFor(
         available: '0.8.23',
       }
     });
+
   let Resolver;
 
   if (require.has(`${engineName}/resolver`)) {

--- a/packages/ember-engines/package.json
+++ b/packages/ember-engines/package.json
@@ -63,7 +63,7 @@
     "ember-qunit": "^5.1.5",
     "ember-resolver": "^7.0.0",
     "ember-sinon": "^4.0.0",
-    "ember-source": "~3.24.1",
+    "ember-source": "~3.12.0",
     "ember-source-channel-url": "^2.0.1",
     "ember-template-lint": "^2.4.0",
     "ember-try": "^1.4.0",

--- a/packages/ember-engines/package.json
+++ b/packages/ember-engines/package.json
@@ -63,7 +63,7 @@
     "ember-qunit": "^5.1.5",
     "ember-resolver": "^7.0.0",
     "ember-sinon": "^4.0.0",
-    "ember-source": "~3.12.0",
+    "ember-source": "~3.24.1",
     "ember-source-channel-url": "^2.0.1",
     "ember-template-lint": "^2.4.0",
     "ember-try": "^1.4.0",

--- a/packages/ember-engines/tests/integration/engine-resolver-test.js
+++ b/packages/ember-engines/tests/integration/engine-resolver-test.js
@@ -16,4 +16,14 @@ module("Integration | Component | engine-resolver-for | hello-name", function(
 
     assert.equal(this.element.innerText.trim(), "Hello, Jerry!");
   });
+
+  test("it deprecates support for `engineResolveFor()`", async function(assert) {
+    assert.expect(1);
+
+    setupRenderingTest(hooks, { resolver: engineResolverFor("eager-blog") });
+
+    assert.deprecationsInclude(
+      "Use of `engineResolverFor` has been deprecated. Instead use `setupEngine(hooks, 'engine-name')` imported from `ember-engines/test-support` to load the engine you need."
+    );
+  });
 });


### PR DESCRIPTION
It adds a deprecation warning to `engineResolverFor` test helper given the new test API released at #653 

cc // @SergeAstapov @runspired 