### PR TITLE
Drop unsupported Node.js versions < 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
       - run: yarn install --frozen-lockfile
       - run: yarn lint
       - run: yarn test:ember
@@ -27,6 +29,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
       - run: yarn install --no-lockfile
       - run: yarn test:ember
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "release-it-yarn-workspaces": "^2.0.0"
   },
   "engines": {
-    "node": "10.* || >= 12"
+    "node": "14.* || 16.* || >= 18"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/packages/ember-engines/README.md
+++ b/packages/ember-engines/README.md
@@ -9,7 +9,7 @@ perspective.
 
 * Ember.js v3.12 or above
 * Ember CLI v3.12 or above
-* Node.js v10 or above
+* Node.js v14 or above
 
 ## Installation
 

--- a/packages/ember-engines/package.json
+++ b/packages/ember-engines/package.json
@@ -114,7 +114,7 @@
     "@ember/legacy-built-in-components": "*"
   },
   "engines": {
-    "node": "10.* || >= 12"
+    "node": "14.* || 16.* || >= 18"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
This is pre-requisite for bumping ember-asset-loader to 1.0.0, which will unblock https://github.com/ef4/ember-auto-import/pull/512

Node.js 12 was EOL in April 2022