### PR TITLE
update fixtures for ember-asset-loader@1.0.0 behavior

### DIFF
--- a/packages/ember-engines/node-tests/fixtures/expected-manifests.json
+++ b/packages/ember-engines/node-tests/fixtures/expected-manifests.json
@@ -1,9 +1,6 @@
 {
   "eager": {
     "bundles": {
-      "eager": {
-        "assets": []
-      }
     }
   },
 
@@ -30,19 +27,10 @@
 
   "eager-in-eager": {
     "bundles": {
-      "eager": {
-        "assets": []
-      },
-      "eager-in-eager": {
-        "assets": []
-      }
     }
   },
   "eager-in-lazy": {
     "bundles": {
-      "eager-in-lazy": {
-        "assets": []
-      },
       "lazy": {
         "assets": [
           {
@@ -68,9 +56,6 @@
 
   "lazy-in-eager": {
     "bundles": {
-      "eager": {
-        "assets": []
-      },
       "lazy-in-eager": {
         "assets": [
           {


### PR DESCRIPTION
The change in https://github.com/ember-engines/ember-asset-loader/pull/123 means that the newer `ember-asset-loader` won't add to the manifest at all if there are no assets - previously there was the package name and an empty `assets` array.

This PR updates the fixtures to meet those new expectations.