### PR TITLE
Make @ember/legacy-built-in-components optional peer dependency

### DIFF
--- a/packages/ember-engines/package.json
+++ b/packages/ember-engines/package.json
@@ -112,6 +112,11 @@
     "ember-source": "^3.12 || 4",
     "@ember/legacy-built-in-components": "*"
   },
+  "peerDependenciesMeta": {
+    "@ember/legacy-built-in-components": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": "14.* || 16.* || >= 18"
   },


### PR DESCRIPTION
as it's truly optional and package managers like pnpm don't blow up