### PR TITLE
enforce no app re-exports for engines

### DIFF
--- a/packages/ember-engines/lib/engine-addon.js
+++ b/packages/ember-engines/lib/engine-addon.js
@@ -641,6 +641,11 @@ function buildEngine(options) {
       return engineRoutesTree;
     };
 
+    // Replace `treeForApp` so no engine files leak into app namespace
+    // This prevents accidental usage of engine components/helpers/utilities
+    // inside of a host app
+    this.treeForApp = function() {};
+
     // Replace `treeForAddon` so that we control how this engine gets built.
     // We may or may not want it to be combined like a default addon.
     this.treeForAddon = function() {

--- a/packages/ember-engines/node-tests/acceptance/build-test.js
+++ b/packages/ember-engines/node-tests/acceptance/build-test.js
@@ -577,6 +577,28 @@ describe('Acceptance', function() {
           );
         });
       });
+      
+    it('correctly ignores app re-exports', async function() {
+      let app = new AddonTestApp();
+      let engineName = 'app-exports';
+
+      await app.create('engine-testing', CreateOptions);
+      let engine = await InRepoEngine.generate(app, engineName, {
+        lazy: true
+      });
+
+      engine.writeFixture(require(`../fixtures/${engineName}/data`));
+
+      let output = await build(app);
+
+      let inAppScope = moduleMatcher(`engine-testing/components/cant-see-me`);
+      let inEngineScope = moduleMatcher(`${engineName}/components/cant-see-me`);
+      output.doesNotContain(`assets/engine-testing.js`, inAppScope);
+      output.contains(
+        `engines-dist/${engineName}/assets/engine.js`,
+        inEngineScope
+      );
+    });
 
     it(
       'correctly separates routes.js and its imports when lazyLoading.includeRoutesInApplication is false',

--- a/packages/ember-engines/node-tests/fixtures/app-exports/data.js
+++ b/packages/ember-engines/node-tests/fixtures/app-exports/data.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+  addon: {
+    components: {
+      'cant-see-me.js': `export default {};`
+    }
+  },
+  app: {
+    components: {
+      'cant-see-me.js': `export default {};`
+    }
+  }
+};


### PR DESCRIPTION
setting an explicit treeForApp to an no-op function will ensure that no engine components leak into host app

some context for this PR:
the way to scaffold files in an engine is the same as an addon which is the conventional way to `ember generate component|helper|util ...`
this has the effect of adding files to the app re-export folder 

because this doesn't cause an obvious failure in the app everything still works it's likely to be missed by users and committed to the repository
the immediate non-obvious effect of this is that engine components will be directly usable in a host app no matter the type of engine
this can lead to the re-exports being included twice in the build

This change makes it so there is no way for those files to make it into the build and brings the functionality in line with the documentation which states [and so anything placed into the `app` directory of an Engine Addon will not be included in the build.](https://github.com/ember-engines/ember-engines.com/blob/master/tests/dummy/app/templates/docs/quickstart.md?plain=1#L219)

This change is important for the embroider initiative with its static analysis of the all components in an app/engines/addons as we try to split the build into the correct bundles as we follow what ember-engines does today and to keep correctness of what the build does under the classic pipeline we adhere to the app-re-exports if any are present

