### PR TITLE
Drop support for Ember.js < 3.28

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,6 @@ jobs:
       fail-fast: false
       matrix:
         ember-try-scenario:
-          - ember-lts-3.24
           - ember-lts-3.28
           - ember-lts-4.4
           - ember-lts-4.8
@@ -60,8 +59,6 @@ jobs:
           # - ember-release
           # - ember-beta
           # - ember-canary
-          - ember-classic
-          - ember-default-with-jquery
 
     steps:
       - uses: actions/checkout@v3

--- a/packages/ember-engines/config/ember-try.js
+++ b/packages/ember-engines/config/ember-try.js
@@ -8,14 +8,6 @@ module.exports = async function () {
     usePnpm: true,
     scenarios: [
       {
-        name: 'ember-lts-3.24',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.24.3',
-          },
-        },
-      },
-      {
         name: 'ember-lts-3.28',
         npm: {
           devDependencies: {
@@ -107,47 +99,6 @@ module.exports = async function () {
             "ember-cli-app-version": "^5.0.0",
           }
         }
-      },
-      // The default `.travis.yml` runs this scenario via `npm test`,
-      // not via `ember try`. It's still included here so that running
-      // `ember try:each` manually or from a customized CI config will run it
-      // along with all the other scenarios.
-      {
-        name: "ember-default",
-        npm: {
-          devDependencies: {}
-        }
-      },
-      {
-        name: "ember-default-with-jquery",
-        env: {
-          EMBER_OPTIONAL_FEATURES: JSON.stringify({
-            'jquery-integration': true,
-          }),
-        },
-        npm: {
-          devDependencies: {
-            '@ember/jquery': '^1.1.0',
-          },
-        },
-      },
-      {
-        name: 'ember-classic',
-        env: {
-          EMBER_OPTIONAL_FEATURES: JSON.stringify({
-            'application-template-wrapper': true,
-            'default-async-observers': false,
-            'template-only-glimmer-components': false,
-          }),
-        },
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.28.0',
-          },
-          ember: {
-            edition: 'classic',
-          },
-        },
       },
       embroiderSafe(),
       embroiderOptimized(),


### PR DESCRIPTION
As we need to have a new major anyways, it's good time to chip away real old version of Ember.js which could make support for green CI harder.

Versions 3.25-3.28 came out with many niceties.
At the same time, users who still can't bump to v4 for whatever reason can use 3.28 easily.