### PR TITLE
Ensure that the engine is destroyed in tests when the test context is cleaned up.

### DIFF
--- a/packages/ember-engines/addon-test-support/index.js
+++ b/packages/ember-engines/addon-test-support/index.js
@@ -1,5 +1,6 @@
 /* global require */
 import { getContext } from '@ember/test-helpers';
+import { associateDestroyableChild } from '@ember/destroyable';
 
 /**
  * Used to set up engine for use. Must be called after one of the `ember-qunit`
@@ -62,6 +63,8 @@ async function buildEngineOwner(owner, engineName) {
       routable: true,
       mountPoint: engineName,
     });
+
+    associateDestroyableChild(owner, engineInstance);
 
     await engineInstance.boot();
   } else {

--- a/packages/ember-engines/tests/integration/setup-engine-test.js
+++ b/packages/ember-engines/tests/integration/setup-engine-test.js
@@ -1,8 +1,9 @@
 import { module, test } from 'qunit';
-import { render, click, visit, currentURL } from '@ember/test-helpers';
+import { render, click, visit, currentURL, teardownContext } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { setupTest, setupRenderingTest, setupApplicationTest } from 'ember-qunit';
 import { setupEngine } from 'ember-engines/test-support';
+import { isDestroyed } from '@ember/destroyable';
 
 module('Integration | setupEngine', function () {
 
@@ -15,6 +16,14 @@ module('Integration | setupEngine', function () {
 
       let route = this.engine.lookup('route:post.likes');
       assert.ok(route);
+    });
+
+    test('it is destroyed with the test context', async function (assert) {
+      assert.expect(2);
+
+      assert.notOk(isDestroyed(this.engine));
+      await teardownContext(this);
+      assert.ok(isDestroyed(this.engine));
     });
   });
 


### PR DESCRIPTION
If the engine is not registered to be destroyed, instances of the engine can be leaked as reported in https://github.com/ember-engines/ember-engines/issues/875.