### PR TITLE
Drop support for Ember.js < 3.28

### DIFF
--- a/packages/ember-engines/package.json
+++ b/packages/ember-engines/package.json
@@ -118,7 +118,7 @@
     "lodash": "^4.17.11"
   },
   "peerDependencies": {
-    "ember-source": "^3.24.1 || 4 || >=5",
+    "ember-source": "^3.28 || 4 || >=5",
     "@ember/legacy-built-in-components": "*"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
this was missed in #870