### PR TITLE
[DEPRECATION] Deprecate transition methods of controller and route per RFC #674

### DIFF
--- a/packages/ember-engines/addon/-private/controller-ext.js
+++ b/packages/ember-engines/addon/-private/controller-ext.js
@@ -1,11 +1,14 @@
 import Controller from '@ember/controller';
 import { getOwner } from '@ember/application';
+import { deprecateTransitionMethods } from './deprecate-transition-methods';
 
 Controller.reopen({
   /*
     Creates an aliased form of a method that properly resolves external routes.
   */
   transitionToExternalRoute(routeName, ...args) {
+    deprecateTransitionMethods('controller', 'transitionToExternalRoute');
+
     let externalRoute = getOwner(this)._getExternalRoute(routeName);
     let target = this.target;
     let method = target.transitionToRoute || target.transitionTo;

--- a/packages/ember-engines/addon/-private/deprecate-transition-methods.js
+++ b/packages/ember-engines/addon/-private/deprecate-transition-methods.js
@@ -1,0 +1,18 @@
+import { deprecate } from '@ember/debug';
+
+export function deprecateTransitionMethods(frameworkClass, methodName) {
+  deprecate(
+    `Calling ${methodName} on a ${frameworkClass} is deprecated. Use the RouterService provided by \`ember-engines-router-service\` instead.`,
+    false,
+    {
+      id: 'ember-engines.transition-methods',
+      for: 'ember-engines',
+      since: {
+        available: '0.10.0',
+        enabled: '0.10.0',
+      },
+      until: '1.0.0',
+      url: 'https://ember-engines.com/docs/deprecations#-transition-methods-of-controller-and-route',
+    },
+  );
+}

--- a/packages/ember-engines/addon/-private/route-ext.js
+++ b/packages/ember-engines/addon/-private/route-ext.js
@@ -1,11 +1,14 @@
 import Route from '@ember/routing/route';
 import { getOwner } from '@ember/application';
+import { deprecateTransitionMethods } from './deprecate-transition-methods';
 
 /*
   Creates an aliased form of a method that properly resolves external routes.
 */
-function externalAlias(methodName) {
+function externalAlias(methodName, deprecatedMethodName) {
   return function _externalAliasMethod(routeName, ...args) {
+    deprecateTransitionMethods('route', deprecatedMethodName);
+
     let externalRoute = getOwner(this)._getExternalRoute(routeName);
     let router = this._router || this.router;
     return router[methodName](externalRoute, ...args);
@@ -13,6 +16,6 @@ function externalAlias(methodName) {
 }
 
 Route.reopen({
-  transitionToExternal: externalAlias('transitionTo'),
-  replaceWithExternal: externalAlias('replaceWith'),
+  transitionToExternal: externalAlias('transitionTo', 'transitionToExternal'),
+  replaceWithExternal: externalAlias('replaceWith', 'replaceWithExternal'),
 });

--- a/packages/ember-engines/tests/acceptance/routeable-engine-demo-test.js
+++ b/packages/ember-engines/tests/acceptance/routeable-engine-demo-test.js
@@ -291,6 +291,9 @@ module('Acceptance | routable engine demo', function (hooks) {
     assert
       .dom('.routable-post-transition-to-home-button')
       .hasClass('transitioned-to-external');
+    assert.deprecationsInclude(
+      'Calling transitionToExternal on a route is deprecated. Use the RouterService provided by `ember-engines-router-service` instead.',
+    );
   });
 
   test("transitionToExternalRoute transitions to the parent application from within an engine's controller and returns a thenable Transition object", async function (assert) {
@@ -306,6 +309,9 @@ module('Acceptance | routable engine demo', function (hooks) {
     assert
       .dom('.routable-post-transition-to-route-home-button')
       .hasClass('transitioned-to-external-route');
+    assert.deprecationsInclude(
+      'Calling transitionToExternalRoute on a controller is deprecated. Use the RouterService provided by `ember-engines-router-service` instead.',
+    );
   });
 
   test('replaceWithExternal transitions to the parent application from within an engine and returns a thenable Transition object', async function (assert) {
@@ -321,6 +327,9 @@ module('Acceptance | routable engine demo', function (hooks) {
     assert
       .dom('.routable-post-replace-with-home-button')
       .hasClass('replaced-with-external');
+    assert.deprecationsInclude(
+      'Calling replaceWithExternal on a route is deprecated. Use the RouterService provided by `ember-engines-router-service` instead.',
+    );
   });
 
   test('loading routes and intermediateTransitionTo work within an engine', async function (assert) {


### PR DESCRIPTION
Deprecate transition methods to match https://github.com/emberjs/rfcs/pull/674 before we remove them in #855

this will be last thing to release in v0.10.0 before we go v1.0.0

TODO:
- [x] to add test cases similar to https://github.com/ember-engines/ember-engines/pull/764/files#diff-7cd3f1c5d330213360758d46650d5c63ca40826002621a02c7f1195a6321459fR119-R151
- [x] open PR to ember-engines.com with deprecation