### PR TITLE
Earlier `<LazyMount>` migrations

### DIFF
--- a/packages/ember-engines/addon/components/lazy-mount.hbs
+++ b/packages/ember-engines/addon/components/lazy-mount.hbs
@@ -1,7 +1,9 @@
+{{this.load @name}}
+
 {{#if this.isLoading}}
-  {{yield (hash isLoading=true error=null)}}
+  {{yield to="loading"}}
 {{else if this.error}}
-  {{yield (hash isLoading=false error=this.error)}}
-{{else}}
+  {{yield this.error to="error"}}
+{{else if this.loadedName}}
   {{mount this.loadedName model=@model}}
 {{/if}}


### PR DESCRIPTION
Heyo 👋 

This was my original `<LazyMount>` migration, to support embroider and classic builds. I modernized the component with a glimmer component (such no positional params) but named blocks and updated the loading of the engine with something that works under embroider as well as requirejs land.

I think, the loading part is the core of this PR.

While doing so and looking at the "modernizations" to `<LazyMount>` that sorta diverge from `{{mount}}` - I think _it might_ be better to revert this `<LazyMount>` component back into a `{{lazy-mount}}` helper.

Either way should be fine, but keeping the helper as an ember component is probably the worst decision to be made here.